### PR TITLE
atlas: update to v0.8.0

### DIFF
--- a/Formula/atlas.rb
+++ b/Formula/atlas.rb
@@ -1,8 +1,8 @@
 class Atlas < Formula
   desc "Project state engine - registry, sessions, capture, and context for ADHD-friendly workflow"
   homepage "https://github.com/Data-Wise/atlas"
-  url "https://github.com/Data-Wise/atlas/archive/refs/tags/v0.7.0.tar.gz"
-  sha256 "f9125afe8d2261d8ce945c79c31ee2d431b221433d58744eefecf1846ab71677"
+  url "https://github.com/Data-Wise/atlas/archive/refs/tags/v0.8.0.tar.gz"
+  sha256 "92ee26b3c60c85f13090634557028d27dfc5039ebc00e59b018b49f128f7ebd1"
   license "MIT"
 
   depends_on "node@20"


### PR DESCRIPTION
Automated update from [atlas release](https://github.com/Data-Wise/atlas/releases/tag/v0.8.0).

**Changes:**
- Version: `v0.8.0`
- SHA256: `92ee26b3c60c85f13090634557028d27dfc5039ebc00e59b018b49f128f7ebd1`

**v0.8.0 Highlights:**
- 🌐 Ecosystem View - See all dev-tools projects (`e` key)
- 🌅 Morning Ritual - `atlas plan` + PlanView (`p` key)
- ⏱️ Time Estimation - Track estimate accuracy
- 🔌 MCP Server - Claude integration

---
_Generated by [Homebrew Release workflow](https://github.com/Data-Wise/atlas/actions/workflows/homebrew-release.yml)_