### PR TITLE
aiterm: update to v0.6.2

### DIFF
--- a/Formula/aiterm.rb
+++ b/Formula/aiterm.rb
@@ -3,8 +3,8 @@ class Aiterm < Formula
 
   desc "Terminal optimizer for AI-assisted development with Claude Code and Gemini CLI"
   homepage "https://github.com/Data-Wise/aiterm"
-  url "https://github.com/Data-Wise/aiterm/archive/v0.6.1.tar.gz"
-  sha256 "4963b1282e1724c2b5eaef648131e73373f4bf4399d5f1e11ced8d3e32ca7406"
+  url "https://github.com/Data-Wise/aiterm/archive/v0.6.2.tar.gz"
+  sha256 "a11c7d9a46700961fa93c38a320011b5c904144265bd0b78e8172ca30f4a93a7"
   license "MIT"
 
   depends_on "python@3.12"


### PR DESCRIPTION
Automated formula update.

**Package:** `aiterm`
**Version:** `v0.6.2`
**SHA256:** `a11c7d9a46700961fa93c38a320011b5c904144265bd0b78e8172ca30f4a93a7`
**Source:** github

---
_Generated by [homebrew-tap reusable workflow](https://github.com/Data-Wise/homebrew-tap/actions)_