### PR TITLE
flow-cli: update to v4.9.1

### DIFF
--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -4,8 +4,8 @@
 class FlowCli < Formula
   desc "ZSH workflow tools designed for ADHD brains"
   homepage "https://data-wise.github.io/flow-cli/"
-  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v4.8.1.tar.gz"
-  sha256 "eac1196c9c982c53f7db207e77675f09c8441220a3d45fccfea525b5750fe0d4"
+  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v4.9.1.tar.gz"
+  sha256 "ee3d2dc89fc4214ff9d1354abdd2464f644b114408a0c840239fa278f95094d2"
   license "MIT"
   head "https://github.com/Data-Wise/flow-cli.git", branch: "main"
 


### PR DESCRIPTION
Automated formula update.

**Package:** `flow-cli`
**Version:** `v4.9.1`
**SHA256:** `ee3d2dc89fc4214ff9d1354abdd2464f644b114408a0c840239fa278f95094d2`
**Source:** github

---
_Generated by [homebrew-tap reusable workflow](https://github.com/Data-Wise/homebrew-tap/actions)_