### PR TITLE
flow-cli: update to v5.4.0

### DIFF
--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -4,8 +4,8 @@
 class FlowCli < Formula
   desc "ZSH workflow tools designed for ADHD brains"
   homepage "https://data-wise.github.io/flow-cli/"
-  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v5.3.0.tar.gz"
-  sha256 "c0b8187cd1b6da9f8b4ae9dc496c98d0b00a21d565415213906223e5065442ba"
+  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v5.4.0.tar.gz"
+  sha256 "21d89beb15325add76ff98c360d957ee0bfd50c8c6092864215c9893b6f99658"
   license "MIT"
   head "https://github.com/Data-Wise/flow-cli.git", branch: "main"
 


### PR DESCRIPTION
Automated formula update.

**Package:** `flow-cli`
**Version:** `v5.4.0`
**SHA256:** `21d89beb15325add76ff98c360d957ee0bfd50c8c6092864215c9893b6f99658`
**Source:** github

---
_Generated by [homebrew-tap reusable workflow](https://github.com/Data-Wise/homebrew-tap/actions)_