### PR TITLE
craft: update to v1.19.0

### DIFF
--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -1,8 +1,8 @@
 class Craft < Formula
   desc "Full-stack developer toolkit - 89 commands, 8 agents, 21 skills - Claude Code plugin"
   homepage "https://github.com/Data-Wise/craft"
-  url "https://github.com/Data-Wise/craft/archive/refs/tags/v1.18.1.tar.gz"
-  sha256 "50e59a45e9f30c45b983a0e7bbcb76122d78039afed071b61a17231e726923e1"
+  url "https://github.com/Data-Wise/craft/archive/refs/tags/v1.19.0.tar.gz"
+  sha256 "c7a2094da8e14bf57bf58555bb4719f29d35dc90d46f1eed60f51dc2226c77b0"
   license "MIT"
 
   depends_on "jq" => :optional
@@ -165,7 +165,7 @@ class Craft < Formula
     assert_predicate libexec/"commands", :directory?
     assert_predicate libexec/"skills", :directory?
     assert_predicate libexec/"agents", :directory?
-    assert_match "1.18.1", shell_output("cat #{libexec}/.claude-plugin/plugin.json")
+    assert_match "1.19.0", shell_output("cat #{libexec}/.claude-plugin/plugin.json")
   end
 
   def caveats


### PR DESCRIPTION
Automated formula update.

**Package:** `craft`
**Version:** `v1.19.0`
**SHA256:** `c7a2094da8e14bf57bf58555bb4719f29d35dc90d46f1eed60f51dc2226c77b0`
**Source:** github

---
_Generated by [homebrew-tap reusable workflow](https://github.com/Data-Wise/homebrew-tap/actions)_