### PR TITLE
scholar: update command counts for v2.3.0 (22 commands)

### DIFF
--- a/Formula/scholar.rb
+++ b/Formula/scholar.rb
@@ -105,9 +105,9 @@ class Scholar < Formula
               echo "To enable, run: claude plugin install scholar@local-plugins"
           fi
           echo ""
-          echo "21 commands available (14 research + 7 teaching):"
-          echo "  /arxiv, /doi, /bib:search, /bib:add"
-          echo "  /teach:exam, /teach:quiz, /teach:syllabus, /teach:homework"
+          echo "22 commands available (10 research + 12 teaching):"
+          echo "  Research: /arxiv, /doi, /bib:search, /bib:add, /manuscript:*, /simulation:*, /scholar:*"
+          echo "  Teaching: /teaching:exam, /teaching:quiz, /teaching:syllabus, /teaching:assignment, /teaching:migrate (NEW)"
       else
           echo "⚠️  Automatic symlink failed (macOS permissions)."
           echo ""
@@ -156,9 +156,9 @@ class Scholar < Formula
       If not auto-enabled, run:
         claude plugin install scholar@local-plugins
 
-      21 commands available for academic workflows:
-        - 14 research commands (literature, manuscript, simulation)
-        - 7 teaching commands (syllabus, assignments, exams, feedback)
+      22 commands available for academic workflows:
+        - 10 research commands (literature, manuscript, simulation, planning)
+        - 12 teaching commands (syllabus, assignments, exams, feedback, validation, migration)
 
       Try: /arxiv "your research topic"
 


### PR DESCRIPTION
Update command count messages in the Scholar formula to reflect v2.3.0 changes:

**Changes:**
- 21 → 22 total commands
- Updated breakdown: 10 research + 12 teaching
- Added `/teaching:migrate` to example commands
- Updated category descriptions to include "validation" and "migration"

**Context:**
The automated formula update (PR #37) correctly updated the version and SHA256, but the install messages still showed the old command counts from v2.2.0.

**Details:**
- New command: `/teaching:migrate` (batch v1→v2 schema migration)
- Teaching commands: 11 → 12 (added migrate)
- Research commands: Reorganized count (10 total)