### PR TITLE
fix(scholar): add plugin cache sync in post_install hook

### DIFF
--- a/Formula/scholar.rb
+++ b/Formula/scholar.rb
@@ -141,6 +141,15 @@ class Scholar < Formula
   def post_install
     # Auto-install plugin after brew install
     system bin/"scholar-install"
+
+    # Sync Claude Code plugin registry with new version
+    # This updates the cache so Claude Code loads the correct version
+    if which("claude")
+      system "claude", "plugin", "update", "scholar@local-plugins"
+    end
+  rescue
+    # Don't fail if claude CLI not available or update fails
+    nil
   end
 
   def post_uninstall


### PR DESCRIPTION
## Problem

Scholar's `post_install` hook was missing the plugin cache sync that Craft has. This meant:

- When users run `brew upgrade scholar`, the symlink updates to the new version
- But Claude Code's internal plugin cache still references the old version
- Users don't see new features until they manually restart Claude Code or run `claude plugin update`

## Solution

Add the same plugin cache sync pattern that Craft uses:

```ruby
def post_install
  system bin/"scholar-install"
  
  # Sync Claude Code plugin registry with new version
  if which("claude")
    system "claude", "plugin", "update", "scholar@local-plugins"
  end
rescue
  nil
end
```

## Benefits

- ✅ Upgrades work seamlessly - new features available immediately
- ✅ Users don't need to manually sync or restart
- ✅ Matches Craft's proven pattern
- ✅ Gracefully handles cases where `claude` CLI isn't available

## Testing

After this change, when users upgrade Scholar:
1. `brew upgrade scholar` runs
2. Post-install hook syncs the plugin cache
3. New features are immediately available in Claude Code

---

**Impact:** Improves upgrade UX for all Scholar users
**Criticality:** Medium (quality-of-life improvement, not breaking)