### PR TITLE
flow-cli: update to v5.15.1

### DIFF
--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -4,8 +4,8 @@
 class FlowCli < Formula
   desc "ZSH workflow tools designed for ADHD brains"
   homepage "https://data-wise.github.io/flow-cli/"
-  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v5.15.0.tar.gz"
-  sha256 "35df8b80cc156b980ce6a9de9f0f2ac9a8621bb01de47066c00d29546c5d6dfa"
+  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v5.15.1.tar.gz"
+  sha256 "8707d9364d2c0760db1222601b689ab5ff818780761c8d3986e7e014cb8aed3d"
   license "MIT"
   head "https://github.com/Data-Wise/flow-cli.git", branch: "main"
 


### PR DESCRIPTION
Automated formula update.

**Package:** `flow-cli`
**Version:** `v5.15.1`
**SHA256:** `8707d9364d2c0760db1222601b689ab5ff818780761c8d3986e7e014cb8aed3d`
**Source:** github

---
_Generated by [homebrew-tap reusable workflow](https://github.com/Data-Wise/homebrew-tap/actions)_