### PR TITLE
docs: sync validation references with CI upgrade

### DIFF
--- a/docs/REFCARD.md
+++ b/docs/REFCARD.md
@@ -70,4 +70,4 @@ python3 generator/generate.py --list       # List all formulas
 | Workflow | Trigger | What it does |
 |----------|---------|-------------|
 | update-formula.yml | Called by project repos on release | Updates version/SHA via sed |
-| validate-formulas.yml | Weekly (Monday 06:00 UTC) | brew style + ruby -c on all 14 |
+| validate-formulas.yml | Weekly (Monday 06:00 UTC) | `brew audit --strict` + `ruby -c` on all 14 |

--- a/docs/ci/validation.md
+++ b/docs/ci/validation.md
@@ -8,9 +8,9 @@ Runs every Monday at 06:00 UTC via `validate-formulas.yml`. Can also be triggere
 
 ## What It Checks
 
-### brew style
+### brew audit --strict
 
-Runs `brew style` on all 14 formulas in `Formula/`. Reports pass/fail count and lists any failing formulas.
+Runs `brew audit --strict` on all 14 formulas using tap-qualified names (`data-wise/tap/<name>`). Reports pass/fail count and lists any failing formulas.
 
 ### ruby -c
 
@@ -23,16 +23,16 @@ Results are written to the GitHub Actions step summary with a pass/fail table.
 ## Running Locally
 
 ```bash
-# Style check all formulas
-for f in Formula/*.rb; do
-  echo -n "$(basename "$f" .rb): "
-  brew style "$f" >/dev/null 2>&1 && echo "PASS" || echo "FAIL"
-done
-
-# Strict audit (reads from tap dir, not worktree)
+# Strict audit (must use tap name, reads from tap dir)
 for f in Formula/*.rb; do
   name=$(basename "$f" .rb)
   brew audit --strict "data-wise/tap/$name" 2>&1
+done
+
+# Style check (accepts file paths)
+for f in Formula/*.rb; do
+  echo -n "$(basename "$f" .rb): "
+  brew style "$f" >/dev/null 2>&1 && echo "PASS" || echo "FAIL"
 done
 
 # Ruby syntax check


### PR DESCRIPTION
## Summary

- Update `docs/ci/validation.md` — heading and description from `brew style` to `brew audit --strict`
- Update `docs/REFCARD.md` — CI workflows table to reflect `brew audit --strict`

Syncs docs with the CI workflow change from PR #91 (commit 4551786).

🤖 Generated with [Claude Code](https://claude.com/claude-code)