### PR TITLE
fix: suppress false update-formula push triggers

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -15,6 +15,28 @@
 name: Update Formula
 
 on:
+  # Manual trigger for testing (no inputs required = dry-run safe)
+  workflow_dispatch:
+    inputs:
+      formula_name:
+        description: 'Formula name (e.g., aiterm)'
+        required: true
+        type: string
+      version:
+        description: 'Version (without v prefix)'
+        required: true
+        type: string
+      sha256:
+        description: 'SHA256 of release tarball'
+        required: true
+        type: string
+      source_type:
+        description: 'Source type'
+        required: false
+        type: string
+        default: 'github'
+
+  # Reusable workflow (called by other repos on release)
   workflow_call:
     inputs:
       formula_name:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to `update-formula.yml` to suppress false push-triggered failures
- Enables manual workflow testing from GitHub Actions UI as a bonus

## Context
The `update-formula.yml` reusable workflow was firing on every push despite only having `workflow_call` as a trigger, causing false failures cluttering the Actions tab. Adding `workflow_dispatch` as an explicit trigger resolves this GitHub Actions quirk.

## Test plan
- [ ] Verify no new false "Update Formula" failures appear after next push to main
- [ ] Verify workflow_dispatch works from Actions tab (with required inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)