### PR TITLE
deprecate(rforge-orchestrator): renamed to `rforge` after monorepo extraction

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -24,7 +24,7 @@ progress: All phases merged to main, repo cleaned up, CI verified
 | scholar | plugin (generated) | Yes | CLEAN |
 | himalaya-mcp | plugin (generated) | Yes | CLEAN |
 | rforge | plugin (generated) | No | CLEAN |
-| rforge-orchestrator | plugin (generated) | Yes | CLEAN |
+| rforge-orchestrator | plugin (legacy) | Yes | DEPRECATED 2026-05-10 → migrate to `rforge` |
 | workflow | plugin (generated) | Yes | CLEAN |
 | aiterm | python | Yes | CLEAN |
 | atlas | node | Yes | CLEAN |

--- a/Formula/rforge-orchestrator.rb
+++ b/Formula/rforge-orchestrator.rb
@@ -2,12 +2,24 @@
 # frozen_string_literal: true
 
 # RforgeOrchestrator formula for the data-wise/tap Homebrew tap.
+#
+# DEPRECATED 2026-05-10: This formula was the original packaging of
+# rforge when it lived inside the claude-plugins monorepo. The plugin
+# was extracted to its own repo (Data-Wise/rforge) and renamed to
+# `rforge`. New users should install:
+#
+#     brew install --HEAD data-wise/tap/rforge
+#
+# This formula is kept for the deprecation grace period; it will be
+# upgraded to `disable!` in a future release, and removed thereafter.
 class RforgeOrchestrator < Formula
   desc "Auto-delegation orchestrator for RForge MCP tools - Claude Code plugin"
-  homepage "https://github.com/Data-Wise/claude-plugins"
+  homepage "https://github.com/Data-Wise/rforge"
   url "https://github.com/Data-Wise/claude-plugins/archive/refs/tags/rforge-orchestrator-v0.1.0.tar.gz"
   sha256 "8c065681864b18c9bea41996aa33bec17b95697ed8330846c8b510bd81bbad2e"
   license "MIT"
+
+  deprecate! date: "2026-05-10", because: "renamed; use `brew install --HEAD data-wise/tap/rforge`"
 
   depends_on "jq" => :optional
 
@@ -170,6 +182,23 @@ class RforgeOrchestrator < Formula
 
   def caveats
     <<~EOS
+      ⚠️  DEPRECATED — This formula is no longer maintained.
+
+      The plugin has been renamed to `rforge` and now lives in its own
+      repository. Migrate with:
+
+          brew uninstall data-wise/tap/rforge-orchestrator
+          rm -rf ~/.claude/plugins/rforge-orchestrator
+          brew install --HEAD data-wise/tap/rforge
+
+      The new formula installs to ~/.claude/plugins/rforge and ships
+      v1.2.0 features (R-aware PreToolUse hook, marketplace install,
+      validation skills, 15 commands).
+
+      ──────────────────────────────────────────────────────
+
+      Legacy install info (for users on this deprecated formula):
+
       The RForge Orchestrator plugin has been installed to:
         ~/.claude/plugins/rforge-orchestrator
 
@@ -180,7 +209,7 @@ class RforgeOrchestrator < Formula
         - Claude Code CLI must be installed
         - RForge MCP server must be configured in ~/.claude/settings.json
 
-      Available commands:
+      Available commands (v0.1.0 had only these three):
         /rforge:analyze  - Analyze R project and recommend tools
         /rforge:quick    - Quick project analysis
         /rforge:thorough - Thorough multi-stage analysis
@@ -188,8 +217,8 @@ class RforgeOrchestrator < Formula
       If symlink failed (macOS permissions), run manually:
         ln -sf $(brew --prefix)/opt/rforge-orchestrator/libexec ~/.claude/plugins/rforge-orchestrator
 
-      For more information:
-        https://github.com/Data-Wise/claude-plugins
+      For the new plugin and full v1.2.0 docs:
+        https://github.com/Data-Wise/rforge
     EOS
   end
 


### PR DESCRIPTION
## Summary

Adds Homebrew's `deprecate!` directive to `Formula/rforge-orchestrator.rb`. Users typing `brew install data-wise/tap/rforge-orchestrator` (muscle memory from the old monorepo days) now see a clear migration warning instead of installing a frozen 0.1.0 build pointing at a deleted monorepo subdir.

## Context

rforge was originally packaged as `rforge-orchestrator` inside `Data-Wise/claude-plugins`. It was extracted to [Data-Wise/rforge](https://github.com/Data-Wise/rforge) and renamed to `rforge`. The active formula is [data-wise/tap/rforge](Formula/rforge.rb) (HEAD-only until v1.2.0 stable release ships).

This PR completes the rename loop — Data-Wise/rforge#1 (merged 2026-05-10) updated the standalone repo's user-facing install docs; this updates the tap side.

## Changes

- **`deprecate! date: "2026-05-10", because: "renamed; use brew install --HEAD data-wise/tap/rforge"`** — yellow warning at install time, no install block (grace period). Will be upgraded to `disable!` in a future PR after ~3 months, then deleted ~6 months out.
- **Header comment** expanded to document the deprecation rationale and escalation path.
- **`homepage`** URL: `Data-Wise/claude-plugins` → `Data-Wise/rforge` (so the deprecation page links go to the active repo).
- **`caveats`** block: prepended with prominent ⚠️ DEPRECATED notice + exact 3-command migration sequence. Legacy install info kept below for users who haven't migrated yet.
- **`url` / `sha256`** unchanged — historically accurate.
- **`.STATUS`** audit row: `CLEAN` → `DEPRECATED 2026-05-10 → migrate to rforge`.

## What users see now

Running `brew install data-wise/tap/rforge-orchestrator` produces:

```
Warning: data-wise/tap/rforge-orchestrator has been deprecated because
it has been renamed; use `brew install --HEAD data-wise/tap/rforge`
```

Plus the migration path printed in `caveats` after install completes.

## Verified

- [x] `ruby -c Formula/rforge-orchestrator.rb` — Syntax OK
- [x] `brew style Formula/rforge-orchestrator.rb` — 0 offenses (caught + fixed `Layout/HashAlignment` and `Layout/LineLength` by shortening to single-line `deprecate!` form)
- [x] Existing `url` / `sha256` preserved — install attempt still resolves the same v0.1.0 tarball if available

## Test plan

- [ ] CI: `brew test-bot` audit on the formula (will flag any remaining issues `brew style` missed)
- [ ] Manual: `brew install data-wise/tap/rforge-orchestrator` from a fresh machine after this merges; confirm the deprecation warning fires and caveats render.

## Follow-ups (not in this PR)

- ~3 months out: upgrade `deprecate!` → `disable!`
- ~6 months out: delete the formula entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)