### PR TITLE
rforge: stable v1.2.0 (drops HEAD-only)

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -5,6 +5,8 @@
 class Rforge < Formula
   desc "R package ecosystem orchestrator - 15 commands - Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v1.2.0.tar.gz"
+  sha256 "013d6e6da1dda7dbe888ec8b58a7c095ec7b9351816c417859f393bac50bd879"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 


### PR DESCRIPTION
## Summary

rforge v1.2.0 was just released: https://github.com/Data-Wise/rforge/releases/tag/v1.2.0

Adds stable \`url\` + \`sha256\` so users can run \`brew install data-wise/tap/rforge\` without \`--HEAD\`.

## Changes

- New \`url\`: tarball at \`v1.2.0\` tag
- New \`sha256\`: \`013d6e6d...50bd879\` (verified via \`curl -sL <tarball> | shasum -a 256\`)
- Existing \`head\` line preserved — \`--HEAD\` install still works for users who want \`main\`

## Verified

- [x] \`ruby -c Formula/rforge.rb\` — Syntax OK
- [x] \`brew style Formula/rforge.rb\` — 0 offenses
- [x] SHA256 is 64-char hex
- [x] Tarball URL is reachable (HTTP 200)

## Related

- rforge release: https://github.com/Data-Wise/rforge/releases/tag/v1.2.0
- Companion tap PR (deprecate \`rforge-orchestrator\`): #103 (already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)