### PR TITLE
.STATUS: rforge formula now ships stable v1.2.0

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -23,7 +23,7 @@ progress: All phases merged to main, repo cleaned up, CI verified
 | craft | plugin (generated) | Yes | CLEAN |
 | scholar | plugin (generated) | Yes | CLEAN |
 | himalaya-mcp | plugin (generated) | Yes | CLEAN |
-| rforge | plugin (generated) | No | CLEAN |
+| rforge | plugin (generated) | No | CLEAN (stable 1.2.0, 2026-05-10) |
 | rforge-orchestrator | plugin (legacy) | Yes | DEPRECATED 2026-05-10 → migrate to `rforge` |
 | workflow | plugin (generated) | Yes | CLEAN |
 | aiterm | python | Yes | CLEAN |


### PR DESCRIPTION
Quick housekeeping — updates the audit table to reflect PR #104 (Formula/rforge.rb stable v1.2.0).

Before: `CLEAN` (HEAD-only)
After:  `CLEAN (stable 1.2.0, 2026-05-10)`

Companion to: rforge https://github.com/Data-Wise/rforge/releases/tag/v1.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)