### PR TITLE
rforge 2.1.0

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -3,10 +3,10 @@
 
 # Rforge formula for the data-wise/tap Homebrew tap.
 class Rforge < Formula
-  desc "R package ecosystem orchestrator - 16 commands - Claude Code plugin"
+  desc "R package ecosystem orchestrator - 28 commands - Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.0.0.tar.gz"
-  sha256 "75bfaf29030a45732dade5d0b8c17be94e30a734fe9c338b878e3d16eac179d3"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.1.0.tar.gz"
+  sha256 "a8dda05e6ee5052a2a3cf0e3b14acd800014b1a40bff417dfaa344255ee00ab2"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 
@@ -179,7 +179,7 @@ class Rforge < Formula
       If not auto-enabled, run:
         claude plugin install rforge@local-plugins
 
-      15 commands for R package ecosystem management.
+      28 commands for R package ecosystem management.
 
       If symlink failed (macOS permissions), run manually:
         ln -sf $(brew --prefix)/opt/rforge/libexec ~/.claude/plugins/rforge

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -178,12 +178,12 @@
     },
     "rforge": {
       "type": "claude-plugin",
-      "desc": "R package ecosystem orchestrator - 16 commands - Claude Code plugin",
+      "desc": "R package ecosystem orchestrator - 28 commands - Claude Code plugin",
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.0.0",
-      "sha256": "75bfaf29030a45732dade5d0b8c17be94e30a734fe9c338b878e3d16eac179d3",
+      "version": "2.1.0",
+      "sha256": "a8dda05e6ee5052a2a3cf0e3b14acd800014b1a40bff417dfaa344255ee00ab2",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "optional": [
@@ -215,7 +215,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "The RForge plugin has been installed to:\n  ~/.claude/plugins/rforge\n\nIf not auto-enabled, run:\n  claude plugin install rforge@local-plugins\n\n15 commands for R package ecosystem management.\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/rforge/libexec ~/.claude/plugins/rforge"
+      "caveats_extra": "The RForge plugin has been installed to:\n  ~/.claude/plugins/rforge\n\nIf not auto-enabled, run:\n  claude plugin install rforge@local-plugins\n\n28 commands for R package ecosystem management.\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/rforge/libexec ~/.claude/plugins/rforge"
     },
     "rforge-orchestrator": {
       "type": "claude-plugin",


### PR DESCRIPTION
Bump rforge to v2.1.0 (r: dev-cycle + quality commands, 16→28). Updates manifest.json (source of truth) + regenerated Formula/rforge.rb; `generate.py rforge --diff` IDENTICAL, ruby -c OK. sha256 a8dda05e for the v2.1.0 source tarball. Also fixes stale command count in desc/caveats.