### PR TITLE
fix(rforge): brew test asserts lib/ not skills/

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -192,6 +192,6 @@ class Rforge < Formula
   test do
     assert_path_exists libexec/".claude-plugin/plugin.json"
     assert_predicate libexec/"commands", :directory?
-    assert_predicate libexec/"skills", :directory?
+    assert_predicate libexec/"lib", :directory?
   end
 end

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -211,7 +211,7 @@
           "type": "directory"
         },
         {
-          "path": "skills",
+          "path": "lib",
           "type": "directory"
         }
       ],


### PR DESCRIPTION
rforge has no top-level skills/ dir (its skill is under .claude-plugin/). The generated brew test asserted libexec/skills → failed. Now asserts lib/. Version unchanged (2.1.0); generate.py --validate OK.