### PR TITLE
obsidian-cli-ops: install obs.1 man page (conditional)

### DIFF
--- a/Formula/obsidian-cli-ops.rb
+++ b/Formula/obsidian-cli-ops.rb
@@ -114,6 +114,12 @@ class ObsidianCliOps < Formula
     # Essential docs
     prefix.install "README.md"
     prefix.install "LICENSE" if (buildpath/"LICENSE").exist?
+
+    # Man page. Shipped from releases that include man/man1/obs.1 (added
+    # 2026-06); absent from v3.2.1, so guard on existence to stay install-safe
+    # on older tarballs and on --HEAD before the page is merged. Homebrew links
+    # it onto MANPATH automatically, so `man obs` works after install.
+    man1.install "man/man1/obs.1" if (buildpath/"man/man1/obs.1").exist?
   end
 
   def post_install


### PR DESCRIPTION
Wires `man1.install "man/man1/obs.1"` into the obsidian-cli-ops formula so `brew install` ships the man page and `man obs` works (Homebrew links `share/man` onto MANPATH automatically).

Guarded on file existence, so it is a no-op on tarballs that predate the page (v3.2.1) and on `--HEAD` before the page merges — install-safe to land now, activates automatically on the first release that includes `man/man1/obs.1`. No url/sha256 change.

Pairs with `Data-Wise/obsidian-cli-ops#25` (which authors the page). Validated: `ruby -c` + `brew style` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)