### PR TITLE
obsidian-cli-ops: 3.2.1 → 3.2.2 (man page + ai --json fix)

### DIFF
--- a/Formula/obsidian-cli-ops.rb
+++ b/Formula/obsidian-cli-ops.rb
@@ -13,9 +13,8 @@ class ObsidianCliOps < Formula
 
   desc "CLI tool for Obsidian vault management with AI-powered graph analysis"
   homepage "https://data-wise.github.io/obsidian-cli-ops/"
-  url "https://github.com/Data-Wise/obsidian-cli-ops/archive/refs/tags/v3.2.1.tar.gz"
-  # RELEASE TODO: shasum -a 256 of the v3.2.1 source tarball (tag not yet cut).
-  sha256 "4ac84f9a9941165f89eb958157b0305100c054170bb31ed0b7b8ce4dfcdc2365"
+  url "https://github.com/Data-Wise/obsidian-cli-ops/archive/refs/tags/v3.2.2.tar.gz"
+  sha256 "b4ddb572efbd49e720bb6d6f9bf080e49b4c4b1eaf1089b5ef6ebe07365184d6"
   license "MIT"
   head "https://github.com/Data-Wise/obsidian-cli-ops.git", branch: "main"
 


### PR DESCRIPTION
Bumps url+sha256 to the v3.2.2 tarball. Resources unchanged. The conditional `man1.install` (from #110) now activates — v3.2.2 ships `man/man1/obs.1`. Verified with `brew reinstall --build-from-source` post-merge.