### PR TITLE
fix: silence depends_on macos deprecation warning

### DIFF
--- a/Casks/scribe-dev.rb
+++ b/Casks/scribe-dev.rb
@@ -22,7 +22,7 @@ cask "scribe-dev" do
   conflicts_with cask: "data-wise/tap/scribe"
 
   # Require macOS 10.15+ (Catalina)
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "Scribe.app"
 

--- a/Casks/scribe.rb
+++ b/Casks/scribe.rb
@@ -35,7 +35,7 @@ cask "scribe" do
   # Conflicts with dev version
   conflicts_with cask: "data-wise/tap/scribe-dev"
   # Require macOS 10.15+ (Catalina)
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "Scribe.app"
 


### PR DESCRIPTION
## Summary

Homebrew deprecated the **string-comparison** form for `depends_on macos:`:

> Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.

The bare symbol `:catalina` is the canonical replacement and already means *"this version or newer"* (a minimum requirement), so the `>=` was redundant.

## Changes

- `Casks/scribe.rb` — `depends_on macos: ">= :catalina"` → `depends_on macos: :catalina`
- `Casks/scribe-dev.rb` — same change

## Verification

`brew style` passes with no offenses for `scribe.rb`. (`scribe-dev.rb` still reports pre-existing `StanzaGrouping` formatting nits unrelated to this change — left untouched to keep the diff focused.)

## Follow-up (out of scope)

The craft Homebrew generator template (`commands/dist/homebrew.md`) emits the deprecated form `depends_on macos: ">= :{min_macos}"`. That should be fixed separately so regenerated casks don't reintroduce the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)