### PR TITLE
docs: document depends_on macos symbol-form cask convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,9 @@ Weekly validation (`validate-formulas.yml`) runs `brew style` + `ruby -c` on all
 
 Casks use architecture-specific blocks (`on_arm`/`on_intel`) with separate SHA256 hashes and URLs. Include `livecheck`, `conflicts_with` for dev/stable variants, `uninstall quit:`, and `zap trash:` for cleanup paths.
 
+- **`depends_on macos:` must use the bare-symbol form** — `depends_on macos: :catalina`, NOT the string-comparison form `depends_on macos: ">= :catalina"`. Homebrew deprecated the string form; a bare symbol already means "this version or newer" (minimum requirement). `brew style` flags the string form.
+- Cask templates for desktop apps are emitted by craft's `dist:homebrew` generator (`craft/commands/dist/homebrew.md`). When a cask convention changes, fix that template too — otherwise regenerated casks reintroduce the old form.
+
 ## Version Update Checklist
 
 When manually updating a formula version:


### PR DESCRIPTION
## Summary

Records the cask convention learned while fixing the `depends_on macos:` deprecation:

- `depends_on macos:` must use the bare-symbol form (`depends_on macos: :catalina`), not the deprecated string-comparison form (`">= :catalina"`).
- Notes that craft's `dist:homebrew` generator is the source for desktop-app cask templates, so convention changes must be applied there too (the root cause of the recent warning).

Docs-only change to `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)