### PR TITLE
rforge: 2.2.0 → 2.6.0

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -1,8 +1,15 @@
 status: Active
-last_session: 2026-02-16
+last_session: 2026-06-10
 milestone: Homebrew refactor complete
 
 progress: All phases merged to main, repo cleaned up, CI verified
+
+📋 Session 2026-06-10 (depends_on macos deprecation fix):
+- Fixed `depends_on macos:` deprecation in scribe + scribe-dev casks (string form `">= :catalina"` → bare symbol `:catalina`) — PR #112 (main c3e2e38)
+- Documented the symbol-form cask convention in CLAUDE.md (Cask Conventions section) — PR #113 (main 7ff9010)
+- Deleted `homebrew-tap-temp` duplicate clone (stale, 353 commits behind, no unique work)
+- Applied guardrails-only branch protection to main: force-push + deletion BLOCKED, no PR gate / no required checks (keeps update-formula.yml `auto_merge: true` direct-push working)
+- ROOT CAUSE fixed upstream in craft (`commands/dist/homebrew.md` generator template) — on craft dev, ships next craft release
 
 📋 Session 2026-02-16 (cont):
 - Fixed update-formula.yml false push triggers (PR #94)
@@ -38,3 +45,4 @@ progress: All phases merged to main, repo cleaned up, CI verified
 → Replace scribe-cli placeholder SHA when v0.3.0 release is created
 → Verify update-formula workflow uses App token correctly (next time a project releases)
 → Monitor: push-trigger suppression may need further investigation (PR #94 fix didn't fully resolve)
+→ After next craft release lands, confirm regenerated casks emit `depends_on macos: :catalina` (proves the generator root-cause fix holds in practice)

--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -5,8 +5,8 @@
 class Rforge < Formula
   desc "R package ecosystem orchestrator — 33 commands — Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.2.0.tar.gz"
-  sha256 "be4b529d74dbf4564df29b4fe77c02581ebfe6c8f819158d67abb05051a5fc43"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.6.0.tar.gz"
+  sha256 "c7d898793132b67f5aa3a643d018c26d890844ac459aa6e8da1dab87c79c411b"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 
@@ -179,7 +179,7 @@ class Rforge < Formula
       If not auto-enabled, run:
         claude plugin install rforge@local-plugins
 
-      28 commands for R package ecosystem management.
+      35 commands for R package ecosystem management.
 
       If symlink failed (macOS permissions), run manually:
         ln -sf $(brew --prefix)/opt/rforge/libexec ~/.claude/plugins/rforge

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -182,8 +182,8 @@
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.2.0",
-      "sha256": "be4b529d74dbf4564df29b4fe77c02581ebfe6c8f819158d67abb05051a5fc43",
+      "version": "2.6.0",
+      "sha256": "c7d898793132b67f5aa3a643d018c26d890844ac459aa6e8da1dab87c79c411b",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "optional": [
@@ -215,7 +215,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "The RForge plugin has been installed to:\n  ~/.claude/plugins/rforge\n\nIf not auto-enabled, run:\n  claude plugin install rforge@local-plugins\n\n28 commands for R package ecosystem management.\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/rforge/libexec ~/.claude/plugins/rforge"
+      "caveats_extra": "The RForge plugin has been installed to:\n  ~/.claude/plugins/rforge\n\nIf not auto-enabled, run:\n  claude plugin install rforge@local-plugins\n\n35 commands for R package ecosystem management.\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/rforge/libexec ~/.claude/plugins/rforge"
     },
     "rforge-orchestrator": {
       "type": "claude-plugin",


### PR DESCRIPTION
Sync the rforge formula to the **v2.6.0** release (live: https://github.com/Data-Wise/rforge/releases/tag/v2.6.0).

- `generator/manifest.json`: rforge `version` 2.2.0 → **2.6.0**, new `sha256` (`c7d89879…` of the v2.6.0 source tarball), caveats 28 → 35 commands
- `Formula/rforge.rb`: regenerated from the manifest — `generator/generate.py rforge --diff` reports **IDENTICAL**
- v2.6.0 bundles cran-incoming hardening + ecosystem-manifest discovery + r:deps-sync + r:submit

(Also carries one pre-existing docs(status) commit that was already on this branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)