### PR TITLE
rforge: 2.6.0 → 2.7.0

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -3,10 +3,10 @@
 
 # Rforge formula for the data-wise/tap Homebrew tap.
 class Rforge < Formula
-  desc "R package ecosystem orchestrator — 33 commands — Claude Code plugin"
+  desc "R package ecosystem orchestrator — 35 commands — Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.6.0.tar.gz"
-  sha256 "c7d898793132b67f5aa3a643d018c26d890844ac459aa6e8da1dab87c79c411b"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.7.0.tar.gz"
+  sha256 "6c31a3162bdce550660c85d328580a4739242a7a436778c5c17b077f1994cf79"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -178,12 +178,12 @@
     },
     "rforge": {
       "type": "claude-plugin",
-      "desc": "R package ecosystem orchestrator \u2014 33 commands \u2014 Claude Code plugin",
+      "desc": "R package ecosystem orchestrator \u2014 35 commands \u2014 Claude Code plugin",
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.6.0",
-      "sha256": "c7d898793132b67f5aa3a643d018c26d890844ac459aa6e8da1dab87c79c411b",
+      "version": "2.7.0",
+      "sha256": "6c31a3162bdce550660c85d328580a4739242a7a436778c5c17b077f1994cf79",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "optional": [


### PR DESCRIPTION
Bump `rforge` formula + generator manifest to v2.7.0 (R-universe early-access tier).

- Stable `url` + `sha256` for the v2.7.0 source tarball
- desc 33 → 35 commands
- `generate.py rforge --diff` → **IDENTICAL** (manifest ↔ formula in sync)
- `ruby -c` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)