### PR TITLE
scholar: 2.17.0 → 2.18.1 (manual formula bump)

### DIFF
--- a/Formula/scholar.rb
+++ b/Formula/scholar.rb
@@ -5,8 +5,8 @@
 class Scholar < Formula
   desc "Academic workflows for research and teaching - Claude Code plugin"
   homepage "https://github.com/Data-Wise/scholar"
-  url "https://github.com/Data-Wise/scholar/archive/refs/tags/v2.17.0.tar.gz"
-  sha256 "5cc83b4bc1ee14395efd85dcdcfcb6731573ad0717f6b302edbca25c05a232d6"
+  url "https://github.com/Data-Wise/scholar/archive/refs/tags/v2.18.1.tar.gz"
+  sha256 "92f24b666cde28ba02395b4595748841080e3e789c6839a95d97d1c1d9a1b1af"
   license "MIT"
 
   depends_on "jq" => :optional


### PR DESCRIPTION
Manual formula update — the Homebrew Release CI auto-update failed on auth (`could not read Username for github.com`) for both v2.18.0 and v2.18.1, leaving the tap two releases stale.

- url → v2.18.1 tarball
- sha256 → `92f24b666cde28ba02395b4595748841080e3e789c6839a95d97d1c1d9a1b1af`
- `ruby -c` syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)