### PR TITLE
fix(formula): create bin/ before writing wrapper scripts (bin.mkpath)

### DIFF
--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -14,6 +14,8 @@ class Craft < Formula
   def install
     libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
 
+    bin.mkpath
+
     (bin/"craft-install").write <<~EOS
       #!/bin/bash
       # NOTE: Not using set -e to handle permission errors gracefully

--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -12,9 +12,9 @@ class Craft < Formula
   depends_on "jq" => :optional
 
   def install
-    libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
-
     bin.mkpath
+
+    libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
 
     (bin/"craft-install").write <<~EOS
       #!/bin/bash
@@ -263,6 +263,7 @@ class Craft < Formula
 
   test do
     assert_path_exists libexec/".claude-plugin/plugin.json"
+    assert_path_exists bin/"craft-install"
     assert_predicate libexec/"commands", :directory?
     assert_predicate libexec/"skills", :directory?
     assert_predicate libexec/"agents", :directory?

--- a/Formula/himalaya-mcp.rb
+++ b/Formula/himalaya-mcp.rb
@@ -14,6 +14,8 @@ class HimalayaMcp < Formula
   depends_on "jq" => :optional
 
   def install
+    bin.mkpath
+
     system "npm", "install", *std_npm_args(prefix: false)
     system "npm", "run", "build"
     system "npm", "run", "build:bundle"
@@ -26,8 +28,6 @@ class HimalayaMcp < Formula
     cp_r "himalaya-mcp-plugin/skills", libexec/"skills"
     cp_r "himalaya-mcp-plugin/agents", libexec/"agents"
     cp_r "himalaya-mcp-plugin/hooks", libexec/"hooks" if (buildpath/"himalaya-mcp-plugin/hooks").exist?
-
-    bin.mkpath
 
     (bin/"himalaya-mcp").write <<~EOS
       #!/bin/bash
@@ -249,6 +249,7 @@ class HimalayaMcp < Formula
 
   test do
     assert_path_exists libexec/".claude-plugin/plugin.json"
+    assert_path_exists bin/"himalaya-mcp"
     assert_path_exists libexec/"dist/index.js"
     assert_predicate libexec/"skills", :directory?
     assert_predicate libexec/"agents", :directory?

--- a/Formula/himalaya-mcp.rb
+++ b/Formula/himalaya-mcp.rb
@@ -27,6 +27,8 @@ class HimalayaMcp < Formula
     cp_r "himalaya-mcp-plugin/agents", libexec/"agents"
     cp_r "himalaya-mcp-plugin/hooks", libexec/"hooks" if (buildpath/"himalaya-mcp-plugin/hooks").exist?
 
+    bin.mkpath
+
     (bin/"himalaya-mcp").write <<~EOS
       #!/bin/bash
       exec node "#{libexec}/dist/cli/setup.js" "$@"

--- a/Formula/mcp-bridge.rb
+++ b/Formula/mcp-bridge.rb
@@ -13,6 +13,8 @@ class McpBridge < Formula
   depends_on "node"
 
   def install
+    bin.mkpath
+
     # Install the server package to libexec
     cd "packages/server" do
       # Copy server files to libexec
@@ -24,8 +26,6 @@ class McpBridge < Formula
       end
 
       # Create bin wrapper for mcp-bridge CLI
-      bin.mkpath
-
       (bin/"mcp-bridge").write <<~EOS
         #!/bin/bash
         exec "#{libexec}/mcp-bridge" "$@"
@@ -92,6 +92,8 @@ class McpBridge < Formula
   end
 
   test do
+    assert_path_exists bin/"mcp-bridge"
+
     # Test that the server starts and responds
     _port = free_port
     pid = fork do

--- a/Formula/mcp-bridge.rb
+++ b/Formula/mcp-bridge.rb
@@ -24,6 +24,8 @@ class McpBridge < Formula
       end
 
       # Create bin wrapper for mcp-bridge CLI
+      bin.mkpath
+
       (bin/"mcp-bridge").write <<~EOS
         #!/bin/bash
         exec "#{libexec}/mcp-bridge" "$@"

--- a/Formula/obsidian-cli-ops.rb
+++ b/Formula/obsidian-cli-ops.rb
@@ -101,6 +101,8 @@ class ObsidianCliOps < Formula
     (libexec/"src").install "src/obs.zsh"
 
     # Launcher → isolated venv interpreter (matches obs.zsh resolution tier 1).
+    bin.mkpath
+
     (bin/"obs").write <<~EOS
       #!/bin/zsh
       # Obsidian CLI Ops launcher (Homebrew-installed)

--- a/Formula/obsidian-cli-ops.rb
+++ b/Formula/obsidian-cli-ops.rb
@@ -91,6 +91,8 @@ class ObsidianCliOps < Formula
   end
 
   def install
+    bin.mkpath
+
     # Build the isolated venv and install ONLY the pinned deps (resources above).
     venv = virtualenv_create(libexec/"venv", "python3.12")
     venv.pip_install resources
@@ -101,8 +103,6 @@ class ObsidianCliOps < Formula
     (libexec/"src").install "src/obs.zsh"
 
     # Launcher → isolated venv interpreter (matches obs.zsh resolution tier 1).
-    bin.mkpath
-
     (bin/"obs").write <<~EOS
       #!/bin/zsh
       # Obsidian CLI Ops launcher (Homebrew-installed)
@@ -151,6 +151,7 @@ class ObsidianCliOps < Formula
 
   test do
     # Core files present.
+    assert_path_exists bin/"obs"
     assert_path_exists libexec/"src/obs.zsh"
     assert_path_exists libexec/"src/python/obs_cli.py"
     assert_path_exists libexec/"schema/vault_db.sql"

--- a/Formula/rforge-orchestrator.rb
+++ b/Formula/rforge-orchestrator.rb
@@ -24,9 +24,9 @@ class RforgeOrchestrator < Formula
   depends_on "jq" => :optional
 
   def install
-    libexec.install Dir["rforge-orchestrator/*"]
-
     bin.mkpath
+
+    libexec.install Dir["rforge-orchestrator/*"]
 
     (bin/"rforge-orchestrator-install").write <<~EOS
       #!/bin/bash
@@ -226,6 +226,7 @@ class RforgeOrchestrator < Formula
 
   test do
     assert_path_exists libexec/".claude-plugin/plugin.json"
+    assert_path_exists bin/"rforge-orchestrator-install"
     assert_predicate libexec/"commands", :directory?
     assert_predicate libexec/"agents", :directory?
   end

--- a/Formula/rforge-orchestrator.rb
+++ b/Formula/rforge-orchestrator.rb
@@ -26,6 +26,8 @@ class RforgeOrchestrator < Formula
   def install
     libexec.install Dir["rforge-orchestrator/*"]
 
+    bin.mkpath
+
     (bin/"rforge-orchestrator-install").write <<~EOS
       #!/bin/bash
       # NOTE: Not using set -e to handle permission errors gracefully

--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -15,6 +15,8 @@ class Rforge < Formula
   def install
     libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
 
+    bin.mkpath
+
     (bin/"rforge-install").write <<~EOS
       #!/bin/bash
       # NOTE: Not using set -e to handle permission errors gracefully

--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -13,9 +13,9 @@ class Rforge < Formula
   depends_on "jq" => :optional
 
   def install
-    libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
-
     bin.mkpath
+
+    libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
 
     (bin/"rforge-install").write <<~EOS
       #!/bin/bash
@@ -193,6 +193,7 @@ class Rforge < Formula
 
   test do
     assert_path_exists libexec/".claude-plugin/plugin.json"
+    assert_path_exists bin/"rforge-install"
     assert_predicate libexec/"commands", :directory?
     assert_predicate libexec/"lib", :directory?
   end

--- a/Formula/scholar.rb
+++ b/Formula/scholar.rb
@@ -12,9 +12,9 @@ class Scholar < Formula
   depends_on "jq" => :optional
 
   def install
-    libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
-
     bin.mkpath
+
+    libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
 
     (bin/"scholar-install").write <<~EOS
       #!/bin/bash
@@ -196,6 +196,7 @@ class Scholar < Formula
 
   test do
     assert_path_exists libexec/".claude-plugin/plugin.json"
+    assert_path_exists bin/"scholar-install"
     assert_predicate libexec/"src/plugin-api/commands", :directory?
     assert_predicate libexec/"src/plugin-api/skills", :directory?
   end

--- a/Formula/scholar.rb
+++ b/Formula/scholar.rb
@@ -14,6 +14,8 @@ class Scholar < Formula
   def install
     libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
 
+    bin.mkpath
+
     (bin/"scholar-install").write <<~EOS
       #!/bin/bash
       # NOTE: Not using set -e to handle permission errors gracefully

--- a/Formula/workflow.rb
+++ b/Formula/workflow.rb
@@ -14,6 +14,8 @@ class Workflow < Formula
   def install
     libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
 
+    bin.mkpath
+
     (bin/"workflow-install").write <<~EOS
       #!/bin/bash
       # NOTE: Not using set -e to handle permission errors gracefully

--- a/Formula/workflow.rb
+++ b/Formula/workflow.rb
@@ -12,9 +12,9 @@ class Workflow < Formula
   depends_on "jq" => :optional
 
   def install
-    libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
-
     bin.mkpath
+
+    libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
 
     (bin/"workflow-install").write <<~EOS
       #!/bin/bash
@@ -195,6 +195,7 @@ class Workflow < Formula
 
   test do
     assert_path_exists libexec/".claude-plugin/plugin.json"
+    assert_path_exists bin/"workflow-install"
     assert_path_exists libexec/"commands/brainstorm.md"
     assert_path_exists libexec/"skills/design/backend-designer.md"
     assert_path_exists libexec/"agents/orchestrator.md"


### PR DESCRIPTION
## Problem

Upgrading any source-built tap formula (e.g. `brew upgrade data-wise/tap/scholar`) fails with an opaque error:

```
Error: Failure while executing; `... build.rb .../scholar.rb` exited with 1.
```

The sandbox swallows the child output. Running the `install` method directly surfaces the real cause:

```
Errno::ENOENT: No such file or directory @ rb_sysopen - .../bin/scholar-install
scholar.rb:17 in Pathname#write
```

## Root cause

All 8 source-built formulae write `(bin/"<name>-install").write` **before** the `bin/` directory exists. `libexec.install` creates `libexec/`, but nothing creates `bin/`. This worked previously because older Homebrew's `Pathname#write` auto-created the parent directory; **portable-ruby 4.0.5 no longer does**, so the write raises `ENOENT`.

## Fix

Add `bin.mkpath` before the first `bin` write in each `install` method.

Affected: `craft`, `himalaya-mcp`, `mcp-bridge`, `obsidian-cli-ops`, `rforge`, `rforge-orchestrator`, `scholar`, `workflow`.

## Verification

- `ruby -c` — Syntax OK on all 8
- `brew style` — 8 files, no offenses
- Reproduced the `ENOENT` failure, confirmed `bin.mkpath` makes `install` succeed

> Note: there is a separate, environmental Homebrew issue on the reporting machine where the sandboxed `build.rb` child crashes at startup for *all* source builds (reproduced with an unrelated formula). That is upstream and out of scope here — this PR fixes the latent formula bug that would otherwise bite once the build harness is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)