### PR TITLE
rforge 2.8.0

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -5,8 +5,8 @@
 class Rforge < Formula
   desc "R package ecosystem orchestrator — 35 commands — Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.7.0.tar.gz"
-  sha256 "6c31a3162bdce550660c85d328580a4739242a7a436778c5c17b077f1994cf79"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.8.0.tar.gz"
+  sha256 "9dc3c5d23da3bcdd42e555636cc6fd3144b1ee08948145dc0aec1d2234f1f597"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -182,8 +182,8 @@
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.7.0",
-      "sha256": "6c31a3162bdce550660c85d328580a4739242a7a436778c5c17b077f1994cf79",
+      "version": "2.8.0",
+      "sha256": "9dc3c5d23da3bcdd42e555636cc6fd3144b1ee08948145dc0aec1d2234f1f597",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "optional": [


### PR DESCRIPTION
Bump `rforge` to **v2.8.0** (GitHub release: https://github.com/Data-Wise/rforge/releases/tag/v2.8.0).

- `Formula/rforge.rb`: stable `url` → `v2.8.0.tar.gz`, `sha256` → `9dc3c5d2…`
- `generator/manifest.json`: matching `version` + `sha256` (kept in lockstep)
- `ruby -c` OK; `generate.py rforge --diff` shows only the **pre-existing** `bin.mkpath`/test drift (tracked by feature/manifest-drift-fix) — no new version/sha drift introduced.

Dual stable+head distribution preserved (`head:` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)