### PR TITLE
rforge 2.9.0

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -5,8 +5,8 @@
 class Rforge < Formula
   desc "R package ecosystem orchestrator — 35 commands — Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.8.0.tar.gz"
-  sha256 "9dc3c5d23da3bcdd42e555636cc6fd3144b1ee08948145dc0aec1d2234f1f597"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.9.0.tar.gz"
+  sha256 "08c45b9b640106f7d3c851a3fc9bb5daf135bca56ea5ac42c0fe6b72b70b17d7"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -182,8 +182,8 @@
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.8.0",
-      "sha256": "9dc3c5d23da3bcdd42e555636cc6fd3144b1ee08948145dc0aec1d2234f1f597",
+      "version": "2.9.0",
+      "sha256": "08c45b9b640106f7d3c851a3fc9bb5daf135bca56ea5ac42c0fe6b72b70b17d7",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "optional": [


### PR DESCRIPTION
Bumps `rforge` to **v2.9.0** (Phase 4 orchestrator + manifest_order).

- `Formula/rforge.rb`: url → `v2.9.0`, sha256 → `08c45b9b640106f7d3c851a3fc9bb5daf135bca56ea5ac42c0fe6b72b70b17d7`
- `generator/manifest.json` `formulas.rforge`: version + sha256 matched (lockstep)

Verification:
- `generate.py rforge --diff` → only the pre-existing `bin.mkpath`/`rforge-install` drift (no version/sha drift)
- `ruby -c Formula/rforge.rb` → Syntax OK
- manifest is valid JSON

Release: https://github.com/Data-Wise/rforge/releases/tag/v2.9.0