### PR TITLE
rforge 2.10.0

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -3,10 +3,10 @@
 
 # Rforge formula for the data-wise/tap Homebrew tap.
 class Rforge < Formula
-  desc "R package ecosystem orchestrator — 35 commands — Claude Code plugin"
+  desc "R package ecosystem orchestrator — 39 commands — Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.9.0.tar.gz"
-  sha256 "08c45b9b640106f7d3c851a3fc9bb5daf135bca56ea5ac42c0fe6b72b70b17d7"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.10.0.tar.gz"
+  sha256 "96ef1108a262ff232807909c0a3122f0f727c140a11743371f8d6fed00de8bd2"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -178,12 +178,12 @@
     },
     "rforge": {
       "type": "claude-plugin",
-      "desc": "R package ecosystem orchestrator — 35 commands — Claude Code plugin",
+      "desc": "R package ecosystem orchestrator — 39 commands — Claude Code plugin",
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.9.0",
-      "sha256": "08c45b9b640106f7d3c851a3fc9bb5daf135bca56ea5ac42c0fe6b72b70b17d7",
+      "version": "2.10.0",
+      "sha256": "96ef1108a262ff232807909c0a3122f0f727c140a11743371f8d6fed00de8bd2",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "optional": [


### PR DESCRIPTION
Bumps rforge to v2.10.0 (S7 review + scaffolding + diff-aware --changed). Formula+manifest in lockstep (sha 96ef1108…, count 35→39). `generate.py rforge --diff` → only pre-existing bin.mkpath drift; `ruby -c` OK. Release: https://github.com/Data-Wise/rforge/releases/tag/v2.10.0