### PR TITLE
rforge 2.11.0 — formula + manifest

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -3,10 +3,10 @@
 
 # Rforge formula for the data-wise/tap Homebrew tap.
 class Rforge < Formula
-  desc "R package ecosystem orchestrator — 39 commands — Claude Code plugin"
+  desc "R package ecosystem orchestrator — 41 commands — Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.10.0.tar.gz"
-  sha256 "96ef1108a262ff232807909c0a3122f0f727c140a11743371f8d6fed00de8bd2"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.11.0.tar.gz"
+  sha256 "196686ebf1725ab2696862d333ff92a1dc53ff9d46a0991a62019c561750ad0d"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -178,12 +178,12 @@
     },
     "rforge": {
       "type": "claude-plugin",
-      "desc": "R package ecosystem orchestrator — 39 commands — Claude Code plugin",
+      "desc": "R package ecosystem orchestrator — 41 commands — Claude Code plugin",
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.10.0",
-      "sha256": "96ef1108a262ff232807909c0a3122f0f727c140a11743371f8d6fed00de8bd2",
+      "version": "2.11.0",
+      "sha256": "196686ebf1725ab2696862d333ff92a1dc53ff9d46a0991a62019c561750ad0d",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "optional": [


### PR DESCRIPTION
rforge v2.11.0 release sync.

- `Formula/rforge.rb` + `generator/manifest.json` in lockstep: url + sha256 (`196686eb…`) → v2.11.0; desc 39 → 41 commands.
- `python3 generator/generate.py rforge --diff` → only the pre-existing `bin.mkpath` / `assert_path_exists bin/"rforge-install"` drift (no version/sha drift).
- `ruby -c Formula/rforge.rb` → Syntax OK.

Release: https://github.com/Data-Wise/rforge/releases/tag/v2.11.0