### PR TITLE
rforge 2.12.0 — formula + manifest

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -5,8 +5,8 @@
 class Rforge < Formula
   desc "R package ecosystem orchestrator — 41 commands — Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.11.1.tar.gz"
-  sha256 "0a5538ba22aee5a156df68d53f9ea047af693eb51ddccbaa749645f0b214c276"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.12.0.tar.gz"
+  sha256 "32f3ed5801a99c3b070edb67ea2c5adf16a2729773bc9500017ec9f9d193487c"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -182,8 +182,8 @@
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.11.1",
-      "sha256": "0a5538ba22aee5a156df68d53f9ea047af693eb51ddccbaa749645f0b214c276",
+      "version": "2.12.0",
+      "sha256": "32f3ed5801a99c3b070edb67ea2c5adf16a2729773bc9500017ec9f9d193487c",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "optional": [


### PR DESCRIPTION
rforge v2.12.0 sync: url + sha256 (`32f3ed58…`) → v2.12.0; desc unchanged (41 commands). `generate.py rforge --diff` shows only pre-existing bin.mkpath drift; `ruby -c` OK. Release: https://github.com/Data-Wise/rforge/releases/tag/v2.12.0