### PR TITLE
wip(scholar): formula → v3.1.0 (sha pending tag) [pairs with scholar#155]

### DIFF
--- a/Formula/scholar.rb
+++ b/Formula/scholar.rb
@@ -5,8 +5,10 @@
 class Scholar < Formula
   desc "Academic workflows for research and teaching - Claude Code plugin"
   homepage "https://github.com/Data-Wise/scholar"
-  url "https://github.com/Data-Wise/scholar/archive/refs/tags/v3.0.1.tar.gz"
-  sha256 "f65886df3030d3f119b2540f3fe0d38ad99aa6b2893e304475c7749b3a0629dd"
+  url "https://github.com/Data-Wise/scholar/archive/refs/tags/v3.1.0.tar.gz"
+  # TODO(blocked on tag): after `git tag v3.1.0 && git push --tags` on Data-Wise/scholar, fill the sha with:
+  #   curl -sL https://github.com/Data-Wise/scholar/archive/refs/tags/v3.1.0.tar.gz | shasum -a 256
+  sha256 "REPLACE_WITH_v3.1.0_TARBALL_SHA256_AFTER_TAGGING"
   license "MIT"
 
   depends_on "jq" => :optional


### PR DESCRIPTION
## Bump scholar formula → v3.1.0 (DRAFT — blocked on the tag)

Pairs with **Data-Wise/scholar#155** (release 3.1.0, which ships scholar's first teaching skill `statistical-pedagogy-framework`). The installed scholar currently serves **0 skills** because the `v3.0.1` bottle predates the skill; this updates the tap to `v3.1.0`.

### Done here
- `Formula/scholar.rb` `url` → `v3.1.0.tar.gz`.

### ⛔ One step left (can't be done until the tag exists)
The `sha256` hashes the GitHub tarball for the **`v3.1.0` tag**, which doesn't exist yet. After scholar#155 merges to main and `v3.1.0` is tagged:

```bash
curl -sL https://github.com/Data-Wise/scholar/archive/refs/tags/v3.1.0.tar.gz | shasum -a 256
# paste the hash into Formula/scholar.rb, then mark this PR ready
```

(or run craft's `dist:homebrew` automation, which computes + commits the sha).

### After merge
`brew upgrade scholar` (or `claude plugin update scholar@local-plugins`) → the plugin serves the skill → the local `~/.claude/skills/statistical-pedagogy-framework` duplicate can be archived (clears the last audit yellow).
