### PR TITLE
chore(rforge): bump to v2.15.0

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -5,8 +5,8 @@
 class Rforge < Formula
   desc "R package ecosystem orchestrator — 41 commands — Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.14.0.tar.gz"
-  sha256 "d1cb2eb12447abebb2d56a119b4b6fbeb9b98a70c2697e5c0a0cca225503dec5"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.15.0.tar.gz"
+  sha256 "d2661fa4d165df5db4b11ad778497a2c77da9a503d15f0df2da4ab230cabd306"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -182,8 +182,8 @@
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.14.0",
-      "sha256": "d1cb2eb12447abebb2d56a119b4b6fbeb9b98a70c2697e5c0a0cca225503dec5",
+      "version": "2.15.0",
+      "sha256": "d2661fa4d165df5db4b11ad778497a2c77da9a503d15f0df2da4ab230cabd306",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "optional": [


### PR DESCRIPTION
Bumps the `rforge` formula + generator manifest to **v2.15.0**.

- `version`: 2.14.0 → 2.15.0
- `sha256`: `d2661fa4d165df5db4b11ad778497a2c77da9a503d15f0df2da4ab230cabd306` (release tarball)

Generator-regenerated (`generator/generate.py`); diff scoped to rforge only — unrelated formula drift restored. `ruby -c Formula/rforge.rb` → Syntax OK.

rforge v2.15.0: lib/rcmd.py code-review remediation (P1–P4), no surface change (41 commands).
Release: https://github.com/Data-Wise/rforge/releases/tag/v2.15.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)