### PR TITLE
feat(install): copy-based plugin install (no symlinks) + jq required + hardening

### DIFF
--- a/.github/workflows/formula-drift.yml
+++ b/.github/workflows/formula-drift.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Check formula drift (regen vs committed)
         run: bash generator/check-drift.sh
+
+      - name: No-symlink install contract (claude-plugin formulas)
+        run: bash tests/test_no_symlink_install.sh

--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -244,9 +244,7 @@ class Craft < Formula
     # Prune old cached plugin versions (keep newest 3)
     begin
       cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/craft")
-      if cache.directory?
-        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
-      end
+      cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree) if cache.directory?
     rescue
       nil
     end

--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -9,7 +9,7 @@ class Craft < Formula
   sha256 "f641adfc37f5af17a372df1c33a50802328598a4e8947c4085039cc0e9438088"
   license "MIT"
 
-  depends_on "jq" => :optional
+  depends_on "jq"
 
   def install
     libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
@@ -20,7 +20,8 @@ class Craft < Formula
 
       PLUGIN_NAME="craft"
       TARGET_DIR="$HOME/.claude/plugins/$PLUGIN_NAME"
-      # Use stable opt path — Homebrew maintains this symlink across upgrades
+      # Copy from the stable opt path — Homebrew repoints opt/<name> across upgrades,
+      # and post_install re-runs this installer to refresh the real copy.
       SOURCE_DIR="$(brew --prefix)/opt/craft/libexec"
 
       # Strip unrecognized keys from plugin.json (Claude Code rejects them)
@@ -34,31 +35,39 @@ class Craft < Formula
       # Create plugins directory if it doesn't exist
       mkdir -p "$HOME/.claude/plugins" 2>/dev/null || true
 
-      # Remove existing installation (handle macOS extended attributes)
+      # Remove any existing installation. NOTE: older versions installed a SYMLINK
+      # here — we now install a REAL copy, so this also MIGRATES legacy symlink
+      # installs to a real directory.
       if [ -L "$TARGET_DIR" ] || [ -d "$TARGET_DIR" ]; then
           rm -rf "$TARGET_DIR" 2>/dev/null || rm -f "$TARGET_DIR" 2>/dev/null || true
       fi
 
-      # Create symlink to Homebrew-managed files
-      # Try multiple approaches for macOS compatibility
+      # Install a REAL copy of the Homebrew-managed files (never a symlink).
+      # Use a tar pipe rather than `cp -R`: tar copies symlinks AS symlinks, so the
+      # intentionally-broken governance test fixtures don't abort the copy on macOS
+      # BSD cp. LINK_SUCCESS gates the success/fallback branches below.
       LINK_SUCCESS=false
-
-      # Method 1: ln -sfh (macOS, replaces symlink atomically, prevents circular symlinks)
-      if ln -sfh "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 2: Standard symlink
-      elif ln -sf "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 3: Remove and recreate
-      elif rm -f "$TARGET_DIR" 2>/dev/null && ln -s "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
+      if [ -d "$SOURCE_DIR" ] && mkdir -p "$TARGET_DIR" 2>/dev/null; then
+          if ( cd "$SOURCE_DIR" && tar cf - . ) 2>/dev/null | ( cd "$TARGET_DIR" && tar xf - ) 2>/dev/null; then
+              # Verify the copy actually landed before declaring success
+              if [ -f "$TARGET_DIR/.claude-plugin/plugin.json" ]; then
+                  LINK_SUCCESS=true
+              fi
+          fi
+          [ "$LINK_SUCCESS" = true ] || rm -rf "$TARGET_DIR" 2>/dev/null || true
       fi
 
       if [ "$LINK_SUCCESS" = true ]; then
-          # Also create symlink in local-marketplace for plugin discovery
+          # Mirror into local-marketplace for plugin discovery — a REAL copy, not a
+          # symlink (also migrates a legacy symlink here). Costs ~2x disk per plugin;
+          # accepted tradeoff for the no-symlinks install policy.
           MARKETPLACE_DIR="$HOME/.claude/local-marketplace"
           mkdir -p "$MARKETPLACE_DIR" 2>/dev/null || true
-          ln -sfh "$TARGET_DIR" "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+          if [ -d "$TARGET_DIR" ]; then
+              rm -rf "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || rm -f "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              mkdir -p "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              ( cd "$TARGET_DIR" && tar cf - . ) 2>/dev/null | ( cd "$MARKETPLACE_DIR/$PLUGIN_NAME" && tar xf - ) 2>/dev/null || true
+          fi
 
           # Add to marketplace.json manifest (required for 'claude plugin install' discovery)
           MANIFEST_FILE="$MARKETPLACE_DIR/.claude-plugin/marketplace.json"
@@ -153,11 +162,11 @@ class Craft < Formula
           echo "  /craft:do, /craft:orchestrate, /brainstorm, /craft:check"
           echo "  Categories: arch, ci, code, dist, docs, git, plan, site, test, workflow"
       else
-          echo "⚠️  Automatic symlink failed (macOS permissions)."
+          echo "⚠️  Automatic install failed (could not copy plugin files)."
           echo ""
-          echo "Run this command manually to complete installation:"
+          echo "Copy the plugin into place manually to complete installation:"
           echo ""
-          echo "  ln -sf $SOURCE_DIR $TARGET_DIR"
+          echo "  mkdir -p $TARGET_DIR && ( cd $SOURCE_DIR && tar cf - . ) | ( cd $TARGET_DIR && tar xf - )"
           echo ""
           exit 0  # Don't fail the brew install
       fi
@@ -225,6 +234,30 @@ class Craft < Formula
       if which("claude")
         system "claude", "plugin", "marketplace", "update", "local-plugins"
         system "claude", "plugin", "update", "craft@local-plugins"
+      else
+        opoo "claude not on PATH - run: claude plugin install craft@local-plugins to finish"
+      end
+    rescue
+      nil
+    end
+
+    # Prune old cached plugin versions (keep newest 3)
+    begin
+      cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/craft")
+      if cache.directory?
+        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
+      end
+    rescue
+      nil
+    end
+
+    # Warn if the installed copy's version drifts from this formula
+    begin
+      require "json"
+      installed = Pathname.new("#{Dir.home}/.claude/plugins/craft/.claude-plugin/plugin.json")
+      if installed.file?
+        iv = JSON.parse(installed.read)["version"]
+        opoo "installed craft v#{iv} != formula v#{version}" if iv && iv.to_s != version.to_s
       end
     rescue
       nil
@@ -254,8 +287,8 @@ class Craft < Formula
       After upgrades, sync Claude Code registry:
         claude plugin update craft@local-plugins
 
-      If symlink failed (macOS permissions), run manually:
-        ln -sf $(brew --prefix)/opt/craft/libexec ~/.claude/plugins/craft
+      If the automatic copy failed (macOS permissions), run manually:
+        mkdir -p ~/.claude/plugins/craft && ( cd $(brew --prefix)/opt/craft/libexec && tar cf - . ) | ( cd ~/.claude/plugins/craft && tar xf - )
 
       For more information:
         https://github.com/Data-Wise/craft

--- a/Formula/himalaya-mcp.rb
+++ b/Formula/himalaya-mcp.rb
@@ -10,8 +10,8 @@ class HimalayaMcp < Formula
   license "MIT"
 
   depends_on "himalaya"
-  depends_on "node"
   depends_on "jq"
+  depends_on "node"
 
   def install
     bin.mkpath
@@ -233,9 +233,7 @@ class HimalayaMcp < Formula
     # Prune old cached plugin versions (keep newest 3)
     begin
       cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/himalaya-mcp")
-      if cache.directory?
-        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
-      end
+      cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree) if cache.directory?
     rescue
       nil
     end

--- a/Formula/himalaya-mcp.rb
+++ b/Formula/himalaya-mcp.rb
@@ -11,7 +11,7 @@ class HimalayaMcp < Formula
 
   depends_on "himalaya"
   depends_on "node"
-  depends_on "jq" => :optional
+  depends_on "jq"
 
   def install
     bin.mkpath
@@ -41,7 +41,8 @@ class HimalayaMcp < Formula
 
       PLUGIN_NAME="himalaya-mcp"
       TARGET_DIR="$HOME/.claude/plugins/$PLUGIN_NAME"
-      # Use stable opt path — Homebrew maintains this symlink across upgrades
+      # Copy from the stable opt path — Homebrew repoints opt/<name> across upgrades,
+      # and post_install re-runs this installer to refresh the real copy.
       SOURCE_DIR="$(brew --prefix)/opt/himalaya-mcp/libexec"
 
       # Strip unrecognized keys from plugin.json (Claude Code rejects them)
@@ -55,31 +56,39 @@ class HimalayaMcp < Formula
       # Create plugins directory if it doesn't exist
       mkdir -p "$HOME/.claude/plugins" 2>/dev/null || true
 
-      # Remove existing installation (handle macOS extended attributes)
+      # Remove any existing installation. NOTE: older versions installed a SYMLINK
+      # here — we now install a REAL copy, so this also MIGRATES legacy symlink
+      # installs to a real directory.
       if [ -L "$TARGET_DIR" ] || [ -d "$TARGET_DIR" ]; then
           rm -rf "$TARGET_DIR" 2>/dev/null || rm -f "$TARGET_DIR" 2>/dev/null || true
       fi
 
-      # Create symlink to Homebrew-managed files
-      # Try multiple approaches for macOS compatibility
+      # Install a REAL copy of the Homebrew-managed files (never a symlink).
+      # Use a tar pipe rather than `cp -R`: tar copies symlinks AS symlinks, so the
+      # intentionally-broken governance test fixtures don't abort the copy on macOS
+      # BSD cp. LINK_SUCCESS gates the success/fallback branches below.
       LINK_SUCCESS=false
-
-      # Method 1: ln -sfh (macOS, replaces symlink atomically, prevents circular symlinks)
-      if ln -sfh "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 2: Standard symlink
-      elif ln -sf "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 3: Remove and recreate
-      elif rm -f "$TARGET_DIR" 2>/dev/null && ln -s "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
+      if [ -d "$SOURCE_DIR" ] && mkdir -p "$TARGET_DIR" 2>/dev/null; then
+          if ( cd "$SOURCE_DIR" && tar cf - . ) 2>/dev/null | ( cd "$TARGET_DIR" && tar xf - ) 2>/dev/null; then
+              # Verify the copy actually landed before declaring success
+              if [ -f "$TARGET_DIR/.claude-plugin/plugin.json" ]; then
+                  LINK_SUCCESS=true
+              fi
+          fi
+          [ "$LINK_SUCCESS" = true ] || rm -rf "$TARGET_DIR" 2>/dev/null || true
       fi
 
       if [ "$LINK_SUCCESS" = true ]; then
-          # Also create symlink in local-marketplace for plugin discovery
+          # Mirror into local-marketplace for plugin discovery — a REAL copy, not a
+          # symlink (also migrates a legacy symlink here). Costs ~2x disk per plugin;
+          # accepted tradeoff for the no-symlinks install policy.
           MARKETPLACE_DIR="$HOME/.claude/local-marketplace"
           mkdir -p "$MARKETPLACE_DIR" 2>/dev/null || true
-          ln -sfh "$TARGET_DIR" "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+          if [ -d "$TARGET_DIR" ]; then
+              rm -rf "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || rm -f "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              mkdir -p "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              ( cd "$TARGET_DIR" && tar cf - . ) 2>/dev/null | ( cd "$MARKETPLACE_DIR/$PLUGIN_NAME" && tar xf - ) 2>/dev/null || true
+          fi
 
           # Add to marketplace.json manifest (required for 'claude plugin install' discovery)
           MANIFEST_FILE="$MARKETPLACE_DIR/.claude-plugin/marketplace.json"
@@ -142,11 +151,11 @@ class HimalayaMcp < Formula
           echo "  /email:morning     - Morning email briefing"
           echo "  /email:help        - Help hub for all commands"
       else
-          echo "⚠️  Automatic symlink failed (macOS permissions)."
+          echo "⚠️  Automatic install failed (could not copy plugin files)."
           echo ""
-          echo "Run this command manually to complete installation:"
+          echo "Copy the plugin into place manually to complete installation:"
           echo ""
-          echo "  ln -sf $SOURCE_DIR $TARGET_DIR"
+          echo "  mkdir -p $TARGET_DIR && ( cd $SOURCE_DIR && tar cf - . ) | ( cd $TARGET_DIR && tar xf - )"
           echo ""
           exit 0  # Don't fail the brew install
       fi
@@ -214,6 +223,30 @@ class HimalayaMcp < Formula
       if which("claude")
         system "claude", "plugin", "marketplace", "update", "local-plugins"
         system "claude", "plugin", "update", "himalaya-mcp@local-plugins"
+      else
+        opoo "claude not on PATH - run: claude plugin install himalaya-mcp@local-plugins to finish"
+      end
+    rescue
+      nil
+    end
+
+    # Prune old cached plugin versions (keep newest 3)
+    begin
+      cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/himalaya-mcp")
+      if cache.directory?
+        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
+      end
+    rescue
+      nil
+    end
+
+    # Warn if the installed copy's version drifts from this formula
+    begin
+      require "json"
+      installed = Pathname.new("#{Dir.home}/.claude/plugins/himalaya-mcp/.claude-plugin/plugin.json")
+      if installed.file?
+        iv = JSON.parse(installed.read)["version"]
+        opoo "installed himalaya-mcp v#{iv} != formula v#{version}" if iv && iv.to_s != version.to_s
       end
     rescue
       nil
@@ -242,8 +275,8 @@ class HimalayaMcp < Formula
       After upgrades, sync Claude Code registry:
         claude plugin update himalaya-mcp@local-plugins
 
-      If symlink failed (macOS permissions), run manually:
-        ln -sf $(brew --prefix)/opt/himalaya-mcp/libexec ~/.claude/plugins/himalaya-mcp
+      If the automatic copy failed (macOS permissions), run manually:
+        mkdir -p ~/.claude/plugins/himalaya-mcp && ( cd $(brew --prefix)/opt/himalaya-mcp/libexec && tar cf - . ) | ( cd ~/.claude/plugins/himalaya-mcp && tar xf - )
 
       For more information:
         https://github.com/Data-Wise/himalaya-mcp

--- a/Formula/rforge-orchestrator.rb
+++ b/Formula/rforge-orchestrator.rb
@@ -21,7 +21,7 @@ class RforgeOrchestrator < Formula
 
   deprecate! date: "2026-05-10", because: "renamed; use `brew install --HEAD data-wise/tap/rforge`"
 
-  depends_on "jq" => :optional
+  depends_on "jq"
 
   def install
     bin.mkpath
@@ -34,7 +34,8 @@ class RforgeOrchestrator < Formula
 
       PLUGIN_NAME="rforge-orchestrator"
       TARGET_DIR="$HOME/.claude/plugins/$PLUGIN_NAME"
-      # Use stable opt path — Homebrew maintains this symlink across upgrades
+      # Copy from the stable opt path — Homebrew repoints opt/<name> across upgrades,
+      # and post_install re-runs this installer to refresh the real copy.
       SOURCE_DIR="$(brew --prefix)/opt/rforge-orchestrator/libexec"
 
       echo "Installing RForgeOrchestrator plugin to Claude Code..."
@@ -42,31 +43,39 @@ class RforgeOrchestrator < Formula
       # Create plugins directory if it doesn't exist
       mkdir -p "$HOME/.claude/plugins" 2>/dev/null || true
 
-      # Remove existing installation (handle macOS extended attributes)
+      # Remove any existing installation. NOTE: older versions installed a SYMLINK
+      # here — we now install a REAL copy, so this also MIGRATES legacy symlink
+      # installs to a real directory.
       if [ -L "$TARGET_DIR" ] || [ -d "$TARGET_DIR" ]; then
           rm -rf "$TARGET_DIR" 2>/dev/null || rm -f "$TARGET_DIR" 2>/dev/null || true
       fi
 
-      # Create symlink to Homebrew-managed files
-      # Try multiple approaches for macOS compatibility
+      # Install a REAL copy of the Homebrew-managed files (never a symlink).
+      # Use a tar pipe rather than `cp -R`: tar copies symlinks AS symlinks, so the
+      # intentionally-broken governance test fixtures don't abort the copy on macOS
+      # BSD cp. LINK_SUCCESS gates the success/fallback branches below.
       LINK_SUCCESS=false
-
-      # Method 1: ln -sfh (macOS, replaces symlink atomically, prevents circular symlinks)
-      if ln -sfh "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 2: Standard symlink
-      elif ln -sf "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 3: Remove and recreate
-      elif rm -f "$TARGET_DIR" 2>/dev/null && ln -s "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
+      if [ -d "$SOURCE_DIR" ] && mkdir -p "$TARGET_DIR" 2>/dev/null; then
+          if ( cd "$SOURCE_DIR" && tar cf - . ) 2>/dev/null | ( cd "$TARGET_DIR" && tar xf - ) 2>/dev/null; then
+              # Verify the copy actually landed before declaring success
+              if [ -f "$TARGET_DIR/.claude-plugin/plugin.json" ]; then
+                  LINK_SUCCESS=true
+              fi
+          fi
+          [ "$LINK_SUCCESS" = true ] || rm -rf "$TARGET_DIR" 2>/dev/null || true
       fi
 
       if [ "$LINK_SUCCESS" = true ]; then
-          # Also create symlink in local-marketplace for plugin discovery
+          # Mirror into local-marketplace for plugin discovery — a REAL copy, not a
+          # symlink (also migrates a legacy symlink here). Costs ~2x disk per plugin;
+          # accepted tradeoff for the no-symlinks install policy.
           MARKETPLACE_DIR="$HOME/.claude/local-marketplace"
           mkdir -p "$MARKETPLACE_DIR" 2>/dev/null || true
-          ln -sfh "$TARGET_DIR" "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+          if [ -d "$TARGET_DIR" ]; then
+              rm -rf "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || rm -f "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              mkdir -p "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              ( cd "$TARGET_DIR" && tar cf - . ) 2>/dev/null | ( cd "$MARKETPLACE_DIR/$PLUGIN_NAME" && tar xf - ) 2>/dev/null || true
+          fi
 
           # Add to marketplace.json manifest (required for 'claude plugin install' discovery)
           MANIFEST_FILE="$MARKETPLACE_DIR/.claude-plugin/marketplace.json"
@@ -117,11 +126,11 @@ class RforgeOrchestrator < Formula
           echo ""
           echo "Commands: /rforge:analyze, /rforge:quick, /rforge:thorough"
       else
-          echo "⚠️  Automatic symlink failed (macOS permissions)."
+          echo "⚠️  Automatic install failed (could not copy plugin files)."
           echo ""
-          echo "Run this command manually to complete installation:"
+          echo "Copy the plugin into place manually to complete installation:"
           echo ""
-          echo "  ln -sf $SOURCE_DIR $TARGET_DIR"
+          echo "  mkdir -p $TARGET_DIR && ( cd $SOURCE_DIR && tar cf - . ) | ( cd $TARGET_DIR && tar xf - )"
           echo ""
           exit 0  # Don't fail the brew install
       fi
@@ -175,6 +184,30 @@ class RforgeOrchestrator < Formula
       if which("claude")
         system "claude", "plugin", "marketplace", "update", "local-plugins"
         system "claude", "plugin", "update", "rforge-orchestrator@local-plugins"
+      else
+        opoo "claude not on PATH - run: claude plugin install rforge-orchestrator@local-plugins to finish"
+      end
+    rescue
+      nil
+    end
+
+    # Prune old cached plugin versions (keep newest 3)
+    begin
+      cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/rforge-orchestrator")
+      if cache.directory?
+        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
+      end
+    rescue
+      nil
+    end
+
+    # Warn if the installed copy's version drifts from this formula
+    begin
+      require "json"
+      installed = Pathname.new("#{Dir.home}/.claude/plugins/rforge-orchestrator/.claude-plugin/plugin.json")
+      if installed.file?
+        iv = JSON.parse(installed.read)["version"]
+        opoo "installed rforge-orchestrator v#{iv} != formula v#{version}" if iv && iv.to_s != version.to_s
       end
     rescue
       nil
@@ -219,8 +252,8 @@ class RforgeOrchestrator < Formula
         /rforge:quick    - Quick project analysis
         /rforge:thorough - Thorough multi-stage analysis
 
-      If symlink failed (macOS permissions), run manually:
-        ln -sf $(brew --prefix)/opt/rforge-orchestrator/libexec ~/.claude/plugins/rforge-orchestrator
+      If the automatic copy failed (macOS permissions), run manually:
+        mkdir -p ~/.claude/plugins/rforge-orchestrator && ( cd $(brew --prefix)/opt/rforge-orchestrator/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge-orchestrator && tar xf - )
 
       For the new plugin and full v1.2.0 docs:
         https://github.com/Data-Wise/rforge

--- a/Formula/rforge-orchestrator.rb
+++ b/Formula/rforge-orchestrator.rb
@@ -194,9 +194,7 @@ class RforgeOrchestrator < Formula
     # Prune old cached plugin versions (keep newest 3)
     begin
       cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/rforge-orchestrator")
-      if cache.directory?
-        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
-      end
+      cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree) if cache.directory?
     rescue
       nil
     end

--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -10,7 +10,7 @@ class Rforge < Formula
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 
-  depends_on "jq" => :optional
+  depends_on "jq"
 
   def install
     libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
@@ -21,7 +21,8 @@ class Rforge < Formula
 
       PLUGIN_NAME="rforge"
       TARGET_DIR="$HOME/.claude/plugins/$PLUGIN_NAME"
-      # Use stable opt path — Homebrew maintains this symlink across upgrades
+      # Copy from the stable opt path — Homebrew repoints opt/<name> across upgrades,
+      # and post_install re-runs this installer to refresh the real copy.
       SOURCE_DIR="$(brew --prefix)/opt/rforge/libexec"
 
       echo "Installing RForge plugin to Claude Code..."
@@ -29,31 +30,39 @@ class Rforge < Formula
       # Create plugins directory if it doesn't exist
       mkdir -p "$HOME/.claude/plugins" 2>/dev/null || true
 
-      # Remove existing installation (handle macOS extended attributes)
+      # Remove any existing installation. NOTE: older versions installed a SYMLINK
+      # here — we now install a REAL copy, so this also MIGRATES legacy symlink
+      # installs to a real directory.
       if [ -L "$TARGET_DIR" ] || [ -d "$TARGET_DIR" ]; then
           rm -rf "$TARGET_DIR" 2>/dev/null || rm -f "$TARGET_DIR" 2>/dev/null || true
       fi
 
-      # Create symlink to Homebrew-managed files
-      # Try multiple approaches for macOS compatibility
+      # Install a REAL copy of the Homebrew-managed files (never a symlink).
+      # Use a tar pipe rather than `cp -R`: tar copies symlinks AS symlinks, so the
+      # intentionally-broken governance test fixtures don't abort the copy on macOS
+      # BSD cp. LINK_SUCCESS gates the success/fallback branches below.
       LINK_SUCCESS=false
-
-      # Method 1: ln -sfh (macOS, replaces symlink atomically, prevents circular symlinks)
-      if ln -sfh "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 2: Standard symlink
-      elif ln -sf "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 3: Remove and recreate
-      elif rm -f "$TARGET_DIR" 2>/dev/null && ln -s "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
+      if [ -d "$SOURCE_DIR" ] && mkdir -p "$TARGET_DIR" 2>/dev/null; then
+          if ( cd "$SOURCE_DIR" && tar cf - . ) 2>/dev/null | ( cd "$TARGET_DIR" && tar xf - ) 2>/dev/null; then
+              # Verify the copy actually landed before declaring success
+              if [ -f "$TARGET_DIR/.claude-plugin/plugin.json" ]; then
+                  LINK_SUCCESS=true
+              fi
+          fi
+          [ "$LINK_SUCCESS" = true ] || rm -rf "$TARGET_DIR" 2>/dev/null || true
       fi
 
       if [ "$LINK_SUCCESS" = true ]; then
-          # Also create symlink in local-marketplace for plugin discovery
+          # Mirror into local-marketplace for plugin discovery — a REAL copy, not a
+          # symlink (also migrates a legacy symlink here). Costs ~2x disk per plugin;
+          # accepted tradeoff for the no-symlinks install policy.
           MARKETPLACE_DIR="$HOME/.claude/local-marketplace"
           mkdir -p "$MARKETPLACE_DIR" 2>/dev/null || true
-          ln -sfh "$TARGET_DIR" "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+          if [ -d "$TARGET_DIR" ]; then
+              rm -rf "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || rm -f "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              mkdir -p "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              ( cd "$TARGET_DIR" && tar cf - . ) 2>/dev/null | ( cd "$MARKETPLACE_DIR/$PLUGIN_NAME" && tar xf - ) 2>/dev/null || true
+          fi
 
           # Add to marketplace.json manifest (required for 'claude plugin install' discovery)
           MANIFEST_FILE="$MARKETPLACE_DIR/.claude-plugin/marketplace.json"
@@ -106,11 +115,11 @@ class Rforge < Formula
           echo "  /rforge:analyze, /rforge:status, /rforge:deps, /rforge:cascade"
           echo "  /rforge:release, /rforge:impact, /rforge:next, /rforge:complete"
       else
-          echo "⚠️  Automatic symlink failed (macOS permissions)."
+          echo "⚠️  Automatic install failed (could not copy plugin files)."
           echo ""
-          echo "Run this command manually to complete installation:"
+          echo "Copy the plugin into place manually to complete installation:"
           echo ""
-          echo "  ln -sf $SOURCE_DIR $TARGET_DIR"
+          echo "  mkdir -p $TARGET_DIR && ( cd $SOURCE_DIR && tar cf - . ) | ( cd $TARGET_DIR && tar xf - )"
           echo ""
           exit 0  # Don't fail the brew install
       fi
@@ -164,6 +173,30 @@ class Rforge < Formula
       if which("claude")
         system "claude", "plugin", "marketplace", "update", "local-plugins"
         system "claude", "plugin", "update", "rforge@local-plugins"
+      else
+        opoo "claude not on PATH - run: claude plugin install rforge@local-plugins to finish"
+      end
+    rescue
+      nil
+    end
+
+    # Prune old cached plugin versions (keep newest 3)
+    begin
+      cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/rforge")
+      if cache.directory?
+        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
+      end
+    rescue
+      nil
+    end
+
+    # Warn if the installed copy's version drifts from this formula
+    begin
+      require "json"
+      installed = Pathname.new("#{Dir.home}/.claude/plugins/rforge/.claude-plugin/plugin.json")
+      if installed.file?
+        iv = JSON.parse(installed.read)["version"]
+        opoo "installed rforge v#{iv} != formula v#{version}" if iv && iv.to_s != version.to_s
       end
     rescue
       nil
@@ -184,8 +217,8 @@ class Rforge < Formula
 
       35 commands for R package ecosystem management.
 
-      If symlink failed (macOS permissions), run manually:
-        ln -sf $(brew --prefix)/opt/rforge/libexec ~/.claude/plugins/rforge
+      If the automatic copy failed (macOS permissions), run manually:
+        mkdir -p ~/.claude/plugins/rforge && ( cd $(brew --prefix)/opt/rforge/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge && tar xf - )
 
       For more information:
         https://github.com/Data-Wise/rforge

--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -183,9 +183,7 @@ class Rforge < Formula
     # Prune old cached plugin versions (keep newest 3)
     begin
       cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/rforge")
-      if cache.directory?
-        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
-      end
+      cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree) if cache.directory?
     rescue
       nil
     end

--- a/Formula/scholar.rb
+++ b/Formula/scholar.rb
@@ -9,7 +9,7 @@ class Scholar < Formula
   sha256 "fd5f82b0468d86268bc345297c2bd1d6d64122a192151f77388edad2509788f7"
   license "MIT"
 
-  depends_on "jq" => :optional
+  depends_on "jq"
 
   def install
     bin.mkpath
@@ -22,7 +22,8 @@ class Scholar < Formula
 
       PLUGIN_NAME="scholar"
       TARGET_DIR="$HOME/.claude/plugins/$PLUGIN_NAME"
-      # Use stable opt path — Homebrew maintains this symlink across upgrades
+      # Copy from the stable opt path — Homebrew repoints opt/<name> across upgrades,
+      # and post_install re-runs this installer to refresh the real copy.
       SOURCE_DIR="$(brew --prefix)/opt/scholar/libexec"
 
       echo "Installing Scholar plugin to Claude Code..."
@@ -30,31 +31,39 @@ class Scholar < Formula
       # Create plugins directory if it doesn't exist
       mkdir -p "$HOME/.claude/plugins" 2>/dev/null || true
 
-      # Remove existing installation (handle macOS extended attributes)
+      # Remove any existing installation. NOTE: older versions installed a SYMLINK
+      # here — we now install a REAL copy, so this also MIGRATES legacy symlink
+      # installs to a real directory.
       if [ -L "$TARGET_DIR" ] || [ -d "$TARGET_DIR" ]; then
           rm -rf "$TARGET_DIR" 2>/dev/null || rm -f "$TARGET_DIR" 2>/dev/null || true
       fi
 
-      # Create symlink to Homebrew-managed files
-      # Try multiple approaches for macOS compatibility
+      # Install a REAL copy of the Homebrew-managed files (never a symlink).
+      # Use a tar pipe rather than `cp -R`: tar copies symlinks AS symlinks, so the
+      # intentionally-broken governance test fixtures don't abort the copy on macOS
+      # BSD cp. LINK_SUCCESS gates the success/fallback branches below.
       LINK_SUCCESS=false
-
-      # Method 1: ln -sfh (macOS, replaces symlink atomically, prevents circular symlinks)
-      if ln -sfh "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 2: Standard symlink
-      elif ln -sf "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 3: Remove and recreate
-      elif rm -f "$TARGET_DIR" 2>/dev/null && ln -s "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
+      if [ -d "$SOURCE_DIR" ] && mkdir -p "$TARGET_DIR" 2>/dev/null; then
+          if ( cd "$SOURCE_DIR" && tar cf - . ) 2>/dev/null | ( cd "$TARGET_DIR" && tar xf - ) 2>/dev/null; then
+              # Verify the copy actually landed before declaring success
+              if [ -f "$TARGET_DIR/.claude-plugin/plugin.json" ]; then
+                  LINK_SUCCESS=true
+              fi
+          fi
+          [ "$LINK_SUCCESS" = true ] || rm -rf "$TARGET_DIR" 2>/dev/null || true
       fi
 
       if [ "$LINK_SUCCESS" = true ]; then
-          # Also create symlink in local-marketplace for plugin discovery
+          # Mirror into local-marketplace for plugin discovery — a REAL copy, not a
+          # symlink (also migrates a legacy symlink here). Costs ~2x disk per plugin;
+          # accepted tradeoff for the no-symlinks install policy.
           MARKETPLACE_DIR="$HOME/.claude/local-marketplace"
           mkdir -p "$MARKETPLACE_DIR" 2>/dev/null || true
-          ln -sfh "$TARGET_DIR" "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+          if [ -d "$TARGET_DIR" ]; then
+              rm -rf "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || rm -f "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              mkdir -p "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              ( cd "$TARGET_DIR" && tar cf - . ) 2>/dev/null | ( cd "$MARKETPLACE_DIR/$PLUGIN_NAME" && tar xf - ) 2>/dev/null || true
+          fi
 
           # Add to marketplace.json manifest (required for 'claude plugin install' discovery)
           MANIFEST_FILE="$MARKETPLACE_DIR/.claude-plugin/marketplace.json"
@@ -107,11 +116,11 @@ class Scholar < Formula
           echo "  Research: /arxiv, /doi, /bib:search, /bib:add, /manuscript:*, /simulation:*, /scholar:*"
           echo "  Teaching: /teaching:exam, /teaching:quiz, /teaching:syllabus, /teaching:assignment, /teaching:lecture, /teaching:sync"
       else
-          echo "⚠️  Automatic symlink failed (macOS permissions)."
+          echo "⚠️  Automatic install failed (could not copy plugin files)."
           echo ""
-          echo "Run this command manually to complete installation:"
+          echo "Copy the plugin into place manually to complete installation:"
           echo ""
-          echo "  ln -sf $SOURCE_DIR $TARGET_DIR"
+          echo "  mkdir -p $TARGET_DIR && ( cd $SOURCE_DIR && tar cf - . ) | ( cd $TARGET_DIR && tar xf - )"
           echo ""
           exit 0  # Don't fail the brew install
       fi
@@ -165,6 +174,30 @@ class Scholar < Formula
       if which("claude")
         system "claude", "plugin", "marketplace", "update", "local-plugins"
         system "claude", "plugin", "update", "scholar@local-plugins"
+      else
+        opoo "claude not on PATH - run: claude plugin install scholar@local-plugins to finish"
+      end
+    rescue
+      nil
+    end
+
+    # Prune old cached plugin versions (keep newest 3)
+    begin
+      cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/scholar")
+      if cache.directory?
+        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
+      end
+    rescue
+      nil
+    end
+
+    # Warn if the installed copy's version drifts from this formula
+    begin
+      require "json"
+      installed = Pathname.new("#{Dir.home}/.claude/plugins/scholar/.claude-plugin/plugin.json")
+      if installed.file?
+        iv = JSON.parse(installed.read)["version"]
+        opoo "installed scholar v#{iv} != formula v#{version}" if iv && iv.to_s != version.to_s
       end
     rescue
       nil
@@ -189,8 +222,8 @@ class Scholar < Formula
 
       Try: /arxiv "your research topic"
 
-      If symlink failed (macOS permissions), run manually:
-        ln -sf $(brew --prefix)/opt/scholar/libexec ~/.claude/plugins/scholar
+      If the automatic copy failed (macOS permissions), run manually:
+        mkdir -p ~/.claude/plugins/scholar && ( cd $(brew --prefix)/opt/scholar/libexec && tar cf - . ) | ( cd ~/.claude/plugins/scholar && tar xf - )
 
       For more information:
         https://github.com/Data-Wise/scholar

--- a/Formula/scholar.rb
+++ b/Formula/scholar.rb
@@ -184,9 +184,7 @@ class Scholar < Formula
     # Prune old cached plugin versions (keep newest 3)
     begin
       cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/scholar")
-      if cache.directory?
-        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
-      end
+      cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree) if cache.directory?
     rescue
       nil
     end

--- a/Formula/workflow.rb
+++ b/Formula/workflow.rb
@@ -9,7 +9,7 @@ class Workflow < Formula
   sha256 "cf155a7ad9855d5c5f4180847b3c62dbda6c99b410485b681b7148f270338783"
   license "MIT"
 
-  depends_on "jq" => :optional
+  depends_on "jq"
 
   def install
     bin.mkpath
@@ -22,7 +22,8 @@ class Workflow < Formula
 
       PLUGIN_NAME="workflow"
       TARGET_DIR="$HOME/.claude/plugins/$PLUGIN_NAME"
-      # Use stable opt path — Homebrew maintains this symlink across upgrades
+      # Copy from the stable opt path — Homebrew repoints opt/<name> across upgrades,
+      # and post_install re-runs this installer to refresh the real copy.
       SOURCE_DIR="$(brew --prefix)/opt/workflow/libexec"
 
       echo "Installing Workflow plugin to Claude Code..."
@@ -30,31 +31,39 @@ class Workflow < Formula
       # Create plugins directory if it doesn't exist
       mkdir -p "$HOME/.claude/plugins" 2>/dev/null || true
 
-      # Remove existing installation (handle macOS extended attributes)
+      # Remove any existing installation. NOTE: older versions installed a SYMLINK
+      # here — we now install a REAL copy, so this also MIGRATES legacy symlink
+      # installs to a real directory.
       if [ -L "$TARGET_DIR" ] || [ -d "$TARGET_DIR" ]; then
           rm -rf "$TARGET_DIR" 2>/dev/null || rm -f "$TARGET_DIR" 2>/dev/null || true
       fi
 
-      # Create symlink to Homebrew-managed files
-      # Try multiple approaches for macOS compatibility
+      # Install a REAL copy of the Homebrew-managed files (never a symlink).
+      # Use a tar pipe rather than `cp -R`: tar copies symlinks AS symlinks, so the
+      # intentionally-broken governance test fixtures don't abort the copy on macOS
+      # BSD cp. LINK_SUCCESS gates the success/fallback branches below.
       LINK_SUCCESS=false
-
-      # Method 1: ln -sfh (macOS, replaces symlink atomically, prevents circular symlinks)
-      if ln -sfh "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 2: Standard symlink
-      elif ln -sf "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
-      # Method 3: Remove and recreate
-      elif rm -f "$TARGET_DIR" 2>/dev/null && ln -s "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-          LINK_SUCCESS=true
+      if [ -d "$SOURCE_DIR" ] && mkdir -p "$TARGET_DIR" 2>/dev/null; then
+          if ( cd "$SOURCE_DIR" && tar cf - . ) 2>/dev/null | ( cd "$TARGET_DIR" && tar xf - ) 2>/dev/null; then
+              # Verify the copy actually landed before declaring success
+              if [ -f "$TARGET_DIR/.claude-plugin/plugin.json" ]; then
+                  LINK_SUCCESS=true
+              fi
+          fi
+          [ "$LINK_SUCCESS" = true ] || rm -rf "$TARGET_DIR" 2>/dev/null || true
       fi
 
       if [ "$LINK_SUCCESS" = true ]; then
-          # Also create symlink in local-marketplace for plugin discovery
+          # Mirror into local-marketplace for plugin discovery — a REAL copy, not a
+          # symlink (also migrates a legacy symlink here). Costs ~2x disk per plugin;
+          # accepted tradeoff for the no-symlinks install policy.
           MARKETPLACE_DIR="$HOME/.claude/local-marketplace"
           mkdir -p "$MARKETPLACE_DIR" 2>/dev/null || true
-          ln -sfh "$TARGET_DIR" "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+          if [ -d "$TARGET_DIR" ]; then
+              rm -rf "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || rm -f "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              mkdir -p "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              ( cd "$TARGET_DIR" && tar cf - . ) 2>/dev/null | ( cd "$MARKETPLACE_DIR/$PLUGIN_NAME" && tar xf - ) 2>/dev/null || true
+          fi
 
           # Add to marketplace.json manifest (required for 'claude plugin install' discovery)
           MANIFEST_FILE="$MARKETPLACE_DIR/.claude-plugin/marketplace.json"
@@ -106,11 +115,11 @@ class Workflow < Formula
           echo "Skills: backend-designer, frontend-designer, devops-helper"
           echo "Commands: /brainstorm, /workflow:spec-review"
       else
-          echo "⚠️  Automatic symlink failed (macOS permissions)."
+          echo "⚠️  Automatic install failed (could not copy plugin files)."
           echo ""
-          echo "Run this command manually to complete installation:"
+          echo "Copy the plugin into place manually to complete installation:"
           echo ""
-          echo "  ln -sf $SOURCE_DIR $TARGET_DIR"
+          echo "  mkdir -p $TARGET_DIR && ( cd $SOURCE_DIR && tar cf - . ) | ( cd $TARGET_DIR && tar xf - )"
           echo ""
           exit 0  # Don't fail the brew install
       fi
@@ -164,6 +173,30 @@ class Workflow < Formula
       if which("claude")
         system "claude", "plugin", "marketplace", "update", "local-plugins"
         system "claude", "plugin", "update", "workflow@local-plugins"
+      else
+        opoo "claude not on PATH - run: claude plugin install workflow@local-plugins to finish"
+      end
+    rescue
+      nil
+    end
+
+    # Prune old cached plugin versions (keep newest 3)
+    begin
+      cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/workflow")
+      if cache.directory?
+        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
+      end
+    rescue
+      nil
+    end
+
+    # Warn if the installed copy's version drifts from this formula
+    begin
+      require "json"
+      installed = Pathname.new("#{Dir.home}/.claude/plugins/workflow/.claude-plugin/plugin.json")
+      if installed.file?
+        iv = JSON.parse(installed.read)["version"]
+        opoo "installed workflow v#{iv} != formula v#{version}" if iv && iv.to_s != version.to_s
       end
     rescue
       nil
@@ -188,8 +221,8 @@ class Workflow < Formula
         - Workflow orchestrator agent
         - 60+ proven design patterns
 
-      If symlink failed (macOS permissions), run manually:
-        ln -sf $(brew --prefix)/opt/workflow/libexec ~/.claude/plugins/workflow
+      If the automatic copy failed (macOS permissions), run manually:
+        mkdir -p ~/.claude/plugins/workflow && ( cd $(brew --prefix)/opt/workflow/libexec && tar cf - . ) | ( cd ~/.claude/plugins/workflow && tar xf - )
 
       For more information:
         https://github.com/Data-Wise/claude-plugins

--- a/Formula/workflow.rb
+++ b/Formula/workflow.rb
@@ -183,9 +183,7 @@ class Workflow < Formula
     # Prune old cached plugin versions (keep newest 3)
     begin
       cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/workflow")
-      if cache.directory?
-        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)
-      end
+      cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree) if cache.directory?
     rescue
       nil
     end

--- a/generator/blocks/fallback.sh
+++ b/generator/blocks/fallback.sh
@@ -1,7 +1,7 @@
-    echo "⚠️  Automatic symlink failed (macOS permissions)."
+    echo "⚠️  Automatic install failed (could not copy plugin files)."
     echo ""
-    echo "Run this command manually to complete installation:"
+    echo "Copy the plugin into place manually to complete installation:"
     echo ""
-    echo "  ln -sf $SOURCE_DIR $TARGET_DIR"
+    echo "  mkdir -p $TARGET_DIR && ( cd $SOURCE_DIR && tar cf - . ) | ( cd $TARGET_DIR && tar xf - )"
     echo ""
     exit 0  # Don't fail the brew install

--- a/generator/blocks/header.sh
+++ b/generator/blocks/header.sh
@@ -3,5 +3,6 @@
 
 PLUGIN_NAME="{plugin_name}"
 TARGET_DIR="$HOME/.claude/plugins/$PLUGIN_NAME"
-# Use stable opt path — Homebrew maintains this symlink across upgrades
+# Copy from the stable opt path — Homebrew repoints opt/<name> across upgrades,
+# and post_install re-runs this installer to refresh the real copy.
 SOURCE_DIR="$(brew --prefix)/opt/{formula_name}/libexec"

--- a/generator/blocks/marketplace.sh
+++ b/generator/blocks/marketplace.sh
@@ -1,7 +1,13 @@
-    # Also create symlink in local-marketplace for plugin discovery
+    # Mirror into local-marketplace for plugin discovery — a REAL copy, not a
+    # symlink (also migrates a legacy symlink here). Costs ~2x disk per plugin;
+    # accepted tradeoff for the no-symlinks install policy.
     MARKETPLACE_DIR="$HOME/.claude/local-marketplace"
     mkdir -p "$MARKETPLACE_DIR" 2>/dev/null || true
-    ln -sfh "$TARGET_DIR" "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+    if [ -d "$TARGET_DIR" ]; then
+        rm -rf "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || rm -f "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+        mkdir -p "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+        ( cd "$TARGET_DIR" && tar cf - . ) 2>/dev/null | ( cd "$MARKETPLACE_DIR/$PLUGIN_NAME" && tar xf - ) 2>/dev/null || true
+    fi
 
     # Add to marketplace.json manifest (required for 'claude plugin install' discovery)
     MANIFEST_FILE="$MARKETPLACE_DIR/.claude-plugin/marketplace.json"

--- a/generator/blocks/symlink.sh
+++ b/generator/blocks/symlink.sh
@@ -3,22 +3,24 @@ echo "Installing {display_name} plugin to Claude Code..."
 # Create plugins directory if it doesn't exist
 mkdir -p "$HOME/.claude/plugins" 2>/dev/null || true
 
-# Remove existing installation (handle macOS extended attributes)
+# Remove any existing installation. NOTE: older versions installed a SYMLINK
+# here — we now install a REAL copy, so this also MIGRATES legacy symlink
+# installs to a real directory.
 if [ -L "$TARGET_DIR" ] || [ -d "$TARGET_DIR" ]; then
     rm -rf "$TARGET_DIR" 2>/dev/null || rm -f "$TARGET_DIR" 2>/dev/null || true
 fi
 
-# Create symlink to Homebrew-managed files
-# Try multiple approaches for macOS compatibility
+# Install a REAL copy of the Homebrew-managed files (never a symlink).
+# Use a tar pipe rather than `cp -R`: tar copies symlinks AS symlinks, so the
+# intentionally-broken governance test fixtures don't abort the copy on macOS
+# BSD cp. LINK_SUCCESS gates the success/fallback branches below.
 LINK_SUCCESS=false
-
-# Method 1: ln -sfh (macOS, replaces symlink atomically, prevents circular symlinks)
-if ln -sfh "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-    LINK_SUCCESS=true
-# Method 2: Standard symlink
-elif ln -sf "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-    LINK_SUCCESS=true
-# Method 3: Remove and recreate
-elif rm -f "$TARGET_DIR" 2>/dev/null && ln -s "$SOURCE_DIR" "$TARGET_DIR" 2>/dev/null; then
-    LINK_SUCCESS=true
+if [ -d "$SOURCE_DIR" ] && mkdir -p "$TARGET_DIR" 2>/dev/null; then
+    if ( cd "$SOURCE_DIR" && tar cf - . ) 2>/dev/null | ( cd "$TARGET_DIR" && tar xf - ) 2>/dev/null; then
+        # Verify the copy actually landed before declaring success
+        if [ -f "$TARGET_DIR/.claude-plugin/plugin.json" ]; then
+            LINK_SUCCESS=true
+        fi
+    fi
+    [ "$LINK_SUCCESS" = true ] || rm -rf "$TARGET_DIR" 2>/dev/null || true
 fi

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -224,10 +224,10 @@ def generate_formula(formula_name, config, defaults):
 
     lines.append("")
 
-    # Dependencies
-    for dep in deps.get("runtime", []):
+    # Dependencies (sorted — Homebrew's FormulaAudit/DependencyOrder wants alphabetical)
+    for dep in sorted(deps.get("runtime", [])):
         lines.append(f'  depends_on "{dep}"')
-    for dep in deps.get("optional", []):
+    for dep in sorted(deps.get("optional", [])):
         lines.append(f'  depends_on "{dep}" => :optional')
 
     lines.append("")
@@ -382,9 +382,7 @@ def generate_formula(formula_name, config, defaults):
     lines.append("    # Prune old cached plugin versions (keep newest 3)")
     lines.append("    begin")
     lines.append(f'      cache = Pathname.new("#{{Dir.home}}/.claude/plugins/cache/local-plugins/{formula_name}")')
-    lines.append("      if cache.directory?")
-    lines.append("        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)")
-    lines.append("      end")
+    lines.append("      cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree) if cache.directory?")
     lines.append("    rescue")
     lines.append("      nil")
     lines.append("    end")

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -370,10 +370,40 @@ def generate_formula(formula_name, config, defaults):
     lines.append('      if which("claude")')
     lines.append('        system "claude", "plugin", "marketplace", "update", "local-plugins"')
     lines.append(f'        system "claude", "plugin", "update", "{formula_name}@local-plugins"')
+    lines.append("      else")
+    lines.append(f'        opoo "claude not on PATH - run: claude plugin install {formula_name}@local-plugins to finish"')
     lines.append("      end")
     lines.append("    rescue")
     lines.append("      nil")
     lines.append("    end")
+    lines.append("")
+
+    # Cache GC: prune old cached plugin versions, keep newest 3 (unbounded growth otherwise)
+    lines.append("    # Prune old cached plugin versions (keep newest 3)")
+    lines.append("    begin")
+    lines.append(f'      cache = Pathname.new("#{{Dir.home}}/.claude/plugins/cache/local-plugins/{formula_name}")')
+    lines.append("      if cache.directory?")
+    lines.append("        cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree)")
+    lines.append("      end")
+    lines.append("    rescue")
+    lines.append("      nil")
+    lines.append("    end")
+
+    # Version-drift self-check (advisory). Skipped for head-only formulas where
+    # `version` is not a released semver and would false-positive.
+    if not head_only:
+        lines.append("")
+        lines.append("    # Warn if the installed copy's version drifts from this formula")
+        lines.append("    begin")
+        lines.append('      require "json"')
+        lines.append(f'      installed = Pathname.new("#{{Dir.home}}/.claude/plugins/{formula_name}/.claude-plugin/plugin.json")')
+        lines.append("      if installed.file?")
+        lines.append('        iv = JSON.parse(installed.read)["version"]')
+        lines.append(f'        opoo "installed {formula_name} v#{{iv}} != formula v#{{version}}" if iv && iv.to_s != version.to_s')
+        lines.append("      end")
+        lines.append("    rescue")
+        lines.append("      nil")
+        lines.append("    end")
 
     lines.append("  end")
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -14,7 +14,7 @@
       "sha256": "f641adfc37f5af17a372df1c33a50802328598a4e8947c4085039cc0e9438088",
       "command_count": 117,
       "dependencies": {
-        "optional": [
+        "runtime": [
           "jq"
         ]
       },
@@ -53,7 +53,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "{command_count} commands for full-stack development:\n  - Architecture & planning\n  - Code generation & refactoring\n  - Testing & CI/CD\n  - Documentation & site generation\n  - Git workflows & branch protection\n  - ADHD-friendly task management\n\nBranch guard protects main/dev from accidental edits.\nBypass: /craft:git:unprotect (session-scoped)\n\nTry: /craft:do \"your task\"\nOr:  /brainstorm\n\nAfter upgrades, sync Claude Code registry:\n  claude plugin update craft@local-plugins\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/craft/libexec ~/.claude/plugins/craft"
+      "caveats_extra": "{command_count} commands for full-stack development:\n  - Architecture & planning\n  - Code generation & refactoring\n  - Testing & CI/CD\n  - Documentation & site generation\n  - Git workflows & branch protection\n  - ADHD-friendly task management\n\nBranch guard protects main/dev from accidental edits.\nBypass: /craft:git:unprotect (session-scoped)\n\nTry: /craft:do \"your task\"\nOr:  /brainstorm\n\nAfter upgrades, sync Claude Code registry:\n  claude plugin update craft@local-plugins\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/craft && ( cd $(brew --prefix)/opt/craft/libexec && tar cf - . ) | ( cd ~/.claude/plugins/craft && tar xf - )"
     },
     "himalaya-mcp": {
       "type": "claude-plugin",
@@ -67,9 +67,7 @@
       "dependencies": {
         "runtime": [
           "himalaya",
-          "node"
-        ],
-        "optional": [
+          "node",
           "jq"
         ]
       },
@@ -155,7 +153,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "12 email skills for Claude Code:\n  /email:inbox   /email:triage   /email:digest\n  /email:reply   /email:compose  /email:attachments\n  /email:search  /email:manage   /email:stats\n  /email:config  /email:morning  /email:help\n\n22 MCP tools available (incl. health_check for IMAP diagnostics).\n\nFor Claude Desktop: himalaya-mcp setup\n\nRequires himalaya CLI with at least one configured account.\nSee: https://github.com/Data-Wise/himalaya-mcp\n\nAfter upgrades, sync Claude Code registry:\n  claude plugin update himalaya-mcp@local-plugins\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/himalaya-mcp/libexec ~/.claude/plugins/himalaya-mcp"
+      "caveats_extra": "12 email skills for Claude Code:\n  /email:inbox   /email:triage   /email:digest\n  /email:reply   /email:compose  /email:attachments\n  /email:search  /email:manage   /email:stats\n  /email:config  /email:morning  /email:help\n\n22 MCP tools available (incl. health_check for IMAP diagnostics).\n\nFor Claude Desktop: himalaya-mcp setup\n\nRequires himalaya CLI with at least one configured account.\nSee: https://github.com/Data-Wise/himalaya-mcp\n\nAfter upgrades, sync Claude Code registry:\n  claude plugin update himalaya-mcp@local-plugins\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/himalaya-mcp && ( cd $(brew --prefix)/opt/himalaya-mcp/libexec && tar cf - . ) | ( cd ~/.claude/plugins/himalaya-mcp && tar xf - )"
     },
     "scholar": {
       "type": "claude-plugin",
@@ -168,7 +166,7 @@
       "command_count": 34,
       "bin_mkpath": true,
       "dependencies": {
-        "optional": [
+        "runtime": [
           "jq"
         ]
       },
@@ -201,7 +199,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "The Scholar plugin has been installed to:\n  ~/.claude/plugins/scholar\n\nIf not auto-enabled, run:\n  claude plugin install scholar@local-plugins\n\n{command_count} commands available for academic workflows:\n  - 14 research commands (literature, manuscript, simulation, planning)\n  - 13 teaching commands (syllabus, assignments, exams, feedback, lectures, validation, migration)\n\nTry: /arxiv \"your research topic\"\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/scholar/libexec ~/.claude/plugins/scholar"
+      "caveats_extra": "The Scholar plugin has been installed to:\n  ~/.claude/plugins/scholar\n\nIf not auto-enabled, run:\n  claude plugin install scholar@local-plugins\n\n{command_count} commands available for academic workflows:\n  - 14 research commands (literature, manuscript, simulation, planning)\n  - 13 teaching commands (syllabus, assignments, exams, feedback, lectures, validation, migration)\n\nTry: /arxiv \"your research topic\"\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/scholar && ( cd $(brew --prefix)/opt/scholar/libexec && tar cf - . ) | ( cd ~/.claude/plugins/scholar && tar xf - )"
     },
     "rforge": {
       "type": "claude-plugin",
@@ -213,7 +211,7 @@
       "sha256": "7683de54d5aaa15f03490236ac5817f4c0f04e4858fd9dc8e7ca05cc53a6ffe2",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
-        "optional": [
+        "runtime": [
           "jq"
         ]
       },
@@ -242,7 +240,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "The RForge plugin has been installed to:\n  ~/.claude/plugins/rforge\n\nIf not auto-enabled, run:\n  claude plugin install rforge@local-plugins\n\n35 commands for R package ecosystem management.\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/rforge/libexec ~/.claude/plugins/rforge"
+      "caveats_extra": "The RForge plugin has been installed to:\n  ~/.claude/plugins/rforge\n\nIf not auto-enabled, run:\n  claude plugin install rforge@local-plugins\n\n35 commands for R package ecosystem management.\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/rforge && ( cd $(brew --prefix)/opt/rforge/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge && tar xf - )"
     },
     "rforge-orchestrator": {
       "type": "claude-plugin",
@@ -262,7 +260,7 @@
         "reason": "renamed; use `brew install --HEAD data-wise/tap/rforge`"
       },
       "dependencies": {
-        "optional": [
+        "runtime": [
           "jq"
         ]
       },
@@ -293,7 +291,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "\u26a0\ufe0f  DEPRECATED \u2014 This formula is no longer maintained.\n\nThe plugin has been renamed to `rforge` and now lives in its own\nrepository. Migrate with:\n\n    brew uninstall data-wise/tap/rforge-orchestrator\n    rm -rf ~/.claude/plugins/rforge-orchestrator\n    brew install --HEAD data-wise/tap/rforge\n\nThe new formula installs to ~/.claude/plugins/rforge and ships\nv1.2.0 features (R-aware PreToolUse hook, marketplace install,\nvalidation skills, 15 commands).\n\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nLegacy install info (for users on this deprecated formula):\n\nThe RForge Orchestrator plugin has been installed to:\n  ~/.claude/plugins/rforge-orchestrator\n\nIf not auto-enabled, run:\n  claude plugin install rforge-orchestrator@local-plugins\n\nRequirements:\n  - Claude Code CLI must be installed\n  - RForge MCP server must be configured in ~/.claude/settings.json\n\nAvailable commands (v0.1.0 had only these three):\n  /rforge:analyze  - Analyze R project and recommend tools\n  /rforge:quick    - Quick project analysis\n  /rforge:thorough - Thorough multi-stage analysis\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/rforge-orchestrator/libexec ~/.claude/plugins/rforge-orchestrator\n\nFor the new plugin and full v1.2.0 docs:\n  https://github.com/Data-Wise/rforge"
+      "caveats_extra": "\u26a0\ufe0f  DEPRECATED \u2014 This formula is no longer maintained.\n\nThe plugin has been renamed to `rforge` and now lives in its own\nrepository. Migrate with:\n\n    brew uninstall data-wise/tap/rforge-orchestrator\n    rm -rf ~/.claude/plugins/rforge-orchestrator\n    brew install --HEAD data-wise/tap/rforge\n\nThe new formula installs to ~/.claude/plugins/rforge and ships\nv1.2.0 features (R-aware PreToolUse hook, marketplace install,\nvalidation skills, 15 commands).\n\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nLegacy install info (for users on this deprecated formula):\n\nThe RForge Orchestrator plugin has been installed to:\n  ~/.claude/plugins/rforge-orchestrator\n\nIf not auto-enabled, run:\n  claude plugin install rforge-orchestrator@local-plugins\n\nRequirements:\n  - Claude Code CLI must be installed\n  - RForge MCP server must be configured in ~/.claude/settings.json\n\nAvailable commands (v0.1.0 had only these three):\n  /rforge:analyze  - Analyze R project and recommend tools\n  /rforge:quick    - Quick project analysis\n  /rforge:thorough - Thorough multi-stage analysis\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/rforge-orchestrator && ( cd $(brew --prefix)/opt/rforge-orchestrator/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge-orchestrator && tar xf - )\n\nFor the new plugin and full v1.2.0 docs:\n  https://github.com/Data-Wise/rforge"
     },
     "workflow": {
       "type": "claude-plugin",
@@ -306,7 +304,7 @@
       "url_override": "https://github.com/Data-Wise/claude-plugins/releases/download/workflow-v{version}/workflow-v{version}.tar.gz",
       "bin_mkpath": true,
       "dependencies": {
-        "optional": [
+        "runtime": [
           "jq"
         ]
       },
@@ -342,7 +340,7 @@
           "type": "file"
         }
       ],
-      "caveats_extra": "The Workflow plugin has been installed to:\n  ~/.claude/plugins/workflow\n\nIf not auto-enabled, run:\n  claude plugin install workflow@local-plugins\n\nThe plugin includes:\n  - 3 auto-activating skills (backend, frontend, devops)\n  - Enhanced /brainstorm command (8 modes)\n  - Workflow orchestrator agent\n  - 60+ proven design patterns\n\nIf symlink failed (macOS permissions), run manually:\n  ln -sf $(brew --prefix)/opt/workflow/libexec ~/.claude/plugins/workflow"
+      "caveats_extra": "The Workflow plugin has been installed to:\n  ~/.claude/plugins/workflow\n\nIf not auto-enabled, run:\n  claude plugin install workflow@local-plugins\n\nThe plugin includes:\n  - 3 auto-activating skills (backend, frontend, devops)\n  - Enhanced /brainstorm command (8 modes)\n  - Workflow orchestrator agent\n  - 60+ proven design patterns\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/workflow && ( cd $(brew --prefix)/opt/workflow/libexec && tar cf - . ) | ( cd ~/.claude/plugins/workflow && tar xf - )"
     },
     "agy": {
       "type": "python-virtualenv",

--- a/tests/test_no_symlink_install.sh
+++ b/tests/test_no_symlink_install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Contract: claude-plugin formulas install REAL copies, never symlinks.
+#
+# Enforces the no-symlinks install policy (SPEC-dist-surface-hardening B):
+#   - no `ln -s` anywhere in a generated claude-plugin formula
+#   - jq is a REQUIRED dependency (not `=> :optional`)
+#   - the install uses a tar-pipe copy
+#
+# Scope: the 6 generated claude-plugin formulas only. Non-plugin formulas
+# (e.g. aiterm's zsh-integration symlink) are out of scope.
+
+set -u
+cd "$(dirname "$0")/.." || exit 2
+
+# Claude-plugin formulas (type == claude-plugin && generated != false)
+PLUGINS=$(python3 -c "
+import json
+m = json.load(open('generator/manifest.json'))
+print(' '.join(n for n, c in m['formulas'].items()
+      if c.get('type') == 'claude-plugin' and c.get('generated', True)))
+")
+
+fail=0
+note() { printf '  %s\n' "$1"; }
+
+for name in $PLUGINS; do
+    f="Formula/${name}.rb"
+    if [ ! -f "$f" ]; then
+        echo "FAIL ${name}: $f missing"; fail=1; continue
+    fi
+
+    # 1. No symlink creation anywhere in the formula
+    if grep -qE '\bln -s' "$f"; then
+        echo "FAIL ${name}: contains 'ln -s' (must install a real copy)"
+        grep -nE '\bln -s' "$f" | sed 's/^/    /'
+        fail=1
+    fi
+
+    # 2. jq is a required dependency, not optional
+    if ! grep -qE '^\s*depends_on "jq"\s*$' "$f"; then
+        echo "FAIL ${name}: jq is not a required dependency (depends_on \"jq\")"
+        fail=1
+    fi
+    if grep -qE 'depends_on "jq" => :optional' "$f"; then
+        echo "FAIL ${name}: jq is still declared :optional"
+        fail=1
+    fi
+
+    # 3. Install uses a tar-pipe copy
+    if ! grep -q 'tar cf - .' "$f"; then
+        echo "FAIL ${name}: no tar-pipe copy found (expected real-copy install)"
+        fail=1
+    fi
+done
+
+if [ "$fail" -eq 0 ]; then
+    echo "PASS: all claude-plugin formulas install real copies (no symlinks, jq required)"
+    echo "  checked: $PLUGINS"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

Cluster B of `craft/docs/specs/SPEC-dist-surface-hardening-2026-07-01.md`. Implements the user's **no-symlinks install policy** across all 6 generated claude-plugin formulas, makes `jq` a real dependency, and hardens `post_install`. All changes are in `generator/` (never hand-edited `.rb`) and regenerate into every formula.

## Changes

**No symlinks (user directive):**
- `blocks/symlink.sh`: the `ln -sfh` chain → a **real copy via tar-pipe**. tar copies symlinks-as-symlinks, so craft's *intentionally-broken* governance test fixtures don't abort the copy the way `cp -R` does on macOS (the D1 lesson). Migrates legacy symlink installs; verifies `plugin.json` landed before declaring success.
- `blocks/marketplace.sh`: local-marketplace mirror is a real copy too (~2× disk per plugin — accepted tradeoff, noted inline).
- `blocks/header.sh`, `blocks/fallback.sh`, all 6 `caveats_extra`: reworded symlink language; manual-fallback prints a tar-pipe command, not `ln -sf`.

**jq required (B1):** moved `jq` `optional → runtime` for all 6 plugin formulas — the marketplace/auto-enable/hook-register logic silently no-op'd without it.

**post_install hardening (`generate.py`):**
- **B2** non-silent when `claude` off PATH (`opoo` with the finish command).
- **B4** cache GC — prune old cached plugin versions, keep newest 3.
- **B3** advisory version-drift warning (installed copy vs formula); skipped for head-only formulas.

**Guard:** `tests/test_no_symlink_install.sh` (+ wired into `formula-drift.yml`) — asserts zero `ln -s`, jq required, tar-pipe copy across the 6 plugin formulas. `aiterm` (python-virtualenv, generated:false) is out of scope; its zsh symlink is legitimate.

## Test evidence

- `generator/generate.py --validate`: all 6 regen + `ruby -c` **OK**.
- `brew style` on all 6: **no offenses**.
- `generator/check-drift.sh`: **no drift** (regen == committed).
- `tests/test_no_symlink_install.sh`: **PASS** (6 formulas).
- **Live tar-pipe copy** of the real installed craft tree: exit 0, 1243/1243 file parity, TARGET is a real directory (not symlink), broken `dead-skill` fixture preserved as a symlink without aborting.

## Ref

- SPEC: `craft/docs/specs/SPEC-dist-surface-hardening-2026-07-01.md` (Cluster B; B5 symlink-fallback superseded by no-symlinks)
- Sequence: D1 ✅ (craft#243) · A ✅ (craft#244) · **B (this)** · C next (craft-mcp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)