### PR TITLE
fix(craft): correct command_count 117→116

### DIFF
--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -158,7 +158,7 @@ class Craft < Formula
               echo "Branch guard hook installed (protects main/dev branches)."
           fi
           echo ""
-          echo "117 commands available:"
+          echo "116 commands available:"
           echo "  /craft:do, /craft:orchestrate, /brainstorm, /craft:check"
           echo "  Categories: arch, ci, code, dist, docs, git, plan, site, test, workflow"
       else
@@ -268,7 +268,7 @@ class Craft < Formula
 
   def caveats
     <<~EOS
-      117 commands for full-stack development:
+      116 commands for full-stack development:
         - Architecture & planning
         - Code generation & refactoring
         - Testing & CI/CD

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -12,7 +12,7 @@
       "repo": "Data-Wise/craft",
       "version": "2.57.0",
       "sha256": "f641adfc37f5af17a372df1c33a50802328598a4e8947c4085039cc0e9438088",
-      "command_count": 117,
+      "command_count": 116,
       "dependencies": {
         "runtime": [
           "jq"


### PR DESCRIPTION
## Problem

`generator/manifest.json` had `command_count: 117` for the craft formula, but craft's actual command count is **116** (`find commands -name '*.md' ! -name index.md ! -name README.md | wc -l` = 116).

`command_count` feeds the `{command_count}` token in `generate.py` (install-script summary + caveats), so the generated `Formula/craft.rb` reported "117 commands" in two places — while `desc` already said "116 commands". The two diverged.

## Root cause

craft's `.github/workflows/homebrew-release.yml` refreshes `craft['desc']` from a live `CMD_COUNT` on release but **never writes `craft['command_count']`**. The field was left frozen at a transient v2.56.0 state (117) while desc stayed current. A follow-up PR on craft co-writes both fields so they can't diverge again.

## Fix

- Set `command_count: 116` in the manifest
- Regenerated `Formula/craft.rb` via `python3 generator/generate.py craft --validate`

Both `desc`, install-script summary, and caveats now read "116 commands".

## Verification

```
$ python3 generator/generate.py craft --validate   → WRITTEN, Syntax OK
$ grep '116 commands\|117 commands' Formula/craft.rb
6:  desc "...with 116 commands"
161:  echo "116 commands available:"
271:  116 commands for full-stack development:
$ bash generator/check-drift.sh                    → ✅ No drift
$ brew style Formula/craft.rb                       → 1 file inspected, no offenses detected
```

Diff touches only `Formula/craft.rb` and `generator/manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)