### PR TITLE
fix(post_install): retry marketplace sync, degrade to advisory on repeated failure

### DIFF
--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -232,8 +232,20 @@ class Craft < Formula
     # Step 3: Sync Claude Code plugin registry (optional)
     begin
       if which("claude")
-        system "claude", "plugin", "marketplace", "update", "local-plugins"
-        system "claude", "plugin", "update", "craft@local-plugins"
+        synced = false
+        2.times do |attempt|
+          synced = system("claude", "plugin", "marketplace", "update", "local-plugins")
+          break if synced
+
+          sleep 1 if attempt.zero?
+        end
+        if synced
+          system "claude", "plugin", "update", "craft@local-plugins"
+        else
+          opoo "marketplace sync didn't settle in time - run: " \
+               "claude plugin marketplace update local-plugins && " \
+               "claude plugin update craft@local-plugins"
+        end
       else
         opoo "claude not on PATH - run: claude plugin install craft@local-plugins to finish"
       end

--- a/Formula/himalaya-mcp.rb
+++ b/Formula/himalaya-mcp.rb
@@ -221,8 +221,20 @@ class HimalayaMcp < Formula
     # Step 3: Sync Claude Code plugin registry (optional)
     begin
       if which("claude")
-        system "claude", "plugin", "marketplace", "update", "local-plugins"
-        system "claude", "plugin", "update", "himalaya-mcp@local-plugins"
+        synced = false
+        2.times do |attempt|
+          synced = system("claude", "plugin", "marketplace", "update", "local-plugins")
+          break if synced
+
+          sleep 1 if attempt.zero?
+        end
+        if synced
+          system "claude", "plugin", "update", "himalaya-mcp@local-plugins"
+        else
+          opoo "marketplace sync didn't settle in time - run: " \
+               "claude plugin marketplace update local-plugins && " \
+               "claude plugin update himalaya-mcp@local-plugins"
+        end
       else
         opoo "claude not on PATH - run: claude plugin install himalaya-mcp@local-plugins to finish"
       end

--- a/Formula/rforge-orchestrator.rb
+++ b/Formula/rforge-orchestrator.rb
@@ -182,8 +182,20 @@ class RforgeOrchestrator < Formula
     # Step 2: Sync Claude Code plugin registry (optional)
     begin
       if which("claude")
-        system "claude", "plugin", "marketplace", "update", "local-plugins"
-        system "claude", "plugin", "update", "rforge-orchestrator@local-plugins"
+        synced = false
+        2.times do |attempt|
+          synced = system("claude", "plugin", "marketplace", "update", "local-plugins")
+          break if synced
+
+          sleep 1 if attempt.zero?
+        end
+        if synced
+          system "claude", "plugin", "update", "rforge-orchestrator@local-plugins"
+        else
+          opoo "marketplace sync didn't settle in time - run: " \
+               "claude plugin marketplace update local-plugins && " \
+               "claude plugin update rforge-orchestrator@local-plugins"
+        end
       else
         opoo "claude not on PATH - run: claude plugin install rforge-orchestrator@local-plugins to finish"
       end

--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -171,8 +171,20 @@ class Rforge < Formula
     # Step 2: Sync Claude Code plugin registry (optional)
     begin
       if which("claude")
-        system "claude", "plugin", "marketplace", "update", "local-plugins"
-        system "claude", "plugin", "update", "rforge@local-plugins"
+        synced = false
+        2.times do |attempt|
+          synced = system("claude", "plugin", "marketplace", "update", "local-plugins")
+          break if synced
+
+          sleep 1 if attempt.zero?
+        end
+        if synced
+          system "claude", "plugin", "update", "rforge@local-plugins"
+        else
+          opoo "marketplace sync didn't settle in time - run: " \
+               "claude plugin marketplace update local-plugins && " \
+               "claude plugin update rforge@local-plugins"
+        end
       else
         opoo "claude not on PATH - run: claude plugin install rforge@local-plugins to finish"
       end

--- a/Formula/scholar.rb
+++ b/Formula/scholar.rb
@@ -172,8 +172,20 @@ class Scholar < Formula
     # Step 2: Sync Claude Code plugin registry (optional)
     begin
       if which("claude")
-        system "claude", "plugin", "marketplace", "update", "local-plugins"
-        system "claude", "plugin", "update", "scholar@local-plugins"
+        synced = false
+        2.times do |attempt|
+          synced = system("claude", "plugin", "marketplace", "update", "local-plugins")
+          break if synced
+
+          sleep 1 if attempt.zero?
+        end
+        if synced
+          system "claude", "plugin", "update", "scholar@local-plugins"
+        else
+          opoo "marketplace sync didn't settle in time - run: " \
+               "claude plugin marketplace update local-plugins && " \
+               "claude plugin update scholar@local-plugins"
+        end
       else
         opoo "claude not on PATH - run: claude plugin install scholar@local-plugins to finish"
       end

--- a/Formula/workflow.rb
+++ b/Formula/workflow.rb
@@ -171,8 +171,20 @@ class Workflow < Formula
     # Step 2: Sync Claude Code plugin registry (optional)
     begin
       if which("claude")
-        system "claude", "plugin", "marketplace", "update", "local-plugins"
-        system "claude", "plugin", "update", "workflow@local-plugins"
+        synced = false
+        2.times do |attempt|
+          synced = system("claude", "plugin", "marketplace", "update", "local-plugins")
+          break if synced
+
+          sleep 1 if attempt.zero?
+        end
+        if synced
+          system "claude", "plugin", "update", "workflow@local-plugins"
+        else
+          opoo "marketplace sync didn't settle in time - run: " \
+               "claude plugin marketplace update local-plugins && " \
+               "claude plugin update workflow@local-plugins"
+        end
       else
         opoo "claude not on PATH - run: claude plugin install workflow@local-plugins to finish"
       end

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -365,11 +365,31 @@ def generate_formula(formula_name, config, defaults):
     # Refresh the local-plugins marketplace index BEFORE updating, so the
     # update reads the freshly-installed version rather than a stale cached
     # manifest (otherwise `plugin update` no-ops on the prior version).
+    #
+    # Retry the marketplace-update call once: Step 2's spawned install script
+    # can return (Process.waitpid) slightly before its marketplace-mirror
+    # write (blocks/marketplace.sh) is fully visible to a freshly-spawned
+    # `claude` CLI process, causing a spurious "marketplace not found" on the
+    # first attempt even though the manifest is actually correct. If both
+    # attempts fail, degrade to an advisory `opoo` with the manual fix-it
+    # command rather than a raw failed-system-call trace.
     lines.append(f'    # Step {"3" if features.get("schema_cleanup") else "2"}: Sync Claude Code plugin registry (optional)')
     lines.append("    begin")
     lines.append('      if which("claude")')
-    lines.append('        system "claude", "plugin", "marketplace", "update", "local-plugins"')
-    lines.append(f'        system "claude", "plugin", "update", "{formula_name}@local-plugins"')
+    lines.append("        synced = false")
+    lines.append("        2.times do |attempt|")
+    lines.append('          synced = system("claude", "plugin", "marketplace", "update", "local-plugins")')
+    lines.append("          break if synced")
+    lines.append("")
+    lines.append("          sleep 1 if attempt.zero?")
+    lines.append("        end")
+    lines.append("        if synced")
+    lines.append(f'          system "claude", "plugin", "update", "{formula_name}@local-plugins"')
+    lines.append("        else")
+    lines.append('          opoo "marketplace sync didn\'t settle in time - run: " \\')
+    lines.append('               "claude plugin marketplace update local-plugins && " \\')
+    lines.append(f'               "claude plugin update {formula_name}@local-plugins"')
+    lines.append("        end")
     lines.append("      else")
     lines.append(f'        opoo "claude not on PATH - run: claude plugin install {formula_name}@local-plugins to finish"')
     lines.append("      end")

--- a/tests/test_marketplace_sync_resilience.sh
+++ b/tests/test_marketplace_sync_resilience.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Contract: claude-plugin formulas retry the post_install marketplace sync
+# and degrade gracefully instead of failing loudly.
+#
+# Root cause (craft session 2026-07-02): Step 2's spawned install script can
+# return (Process.waitpid) slightly before its marketplace-mirror write
+# (blocks/marketplace.sh) is visible to a freshly-spawned `claude` CLI
+# process, causing a spurious "marketplace not found" on `brew reinstall`
+# even though the manifest is actually correct. Fix: retry once with a
+# short delay, then degrade to an advisory `opoo` with the manual fix-it
+# command instead of a raw failed-system-call trace.
+#
+# Scope: the 6 generated claude-plugin formulas only.
+
+set -u
+cd "$(dirname "$0")/.." || exit 2
+
+PLUGINS=$(python3 -c "
+import json
+m = json.load(open('generator/manifest.json'))
+print(' '.join(n for n, c in m['formulas'].items()
+      if c.get('type') == 'claude-plugin' and c.get('generated', True)
+      and c.get('features', {}).get('marketplace')))
+")
+
+fail=0
+
+for name in $PLUGINS; do
+    f="Formula/${name}.rb"
+    if [ ! -f "$f" ]; then
+        echo "FAIL ${name}: $f missing"; fail=1; continue
+    fi
+
+    # 1. Retries the marketplace-update call (not a single unconditional fire)
+    if ! grep -q '2.times do |attempt|' "$f"; then
+        echo "FAIL ${name}: no retry loop around marketplace-update"
+        fail=1
+    fi
+
+    # 2. Breaks out early once synced (doesn't burn the full retry budget on success)
+    if ! grep -qE '^\s*break if synced\s*$' "$f"; then
+        echo "FAIL ${name}: retry loop doesn't short-circuit on success (break if synced)"
+        fail=1
+    fi
+
+    # 3. Degrades to an advisory message on repeated failure, not a raw trace
+    if ! grep -q "didn't settle in time" "$f"; then
+        echo "FAIL ${name}: no advisory opoo fallback for repeated sync failure"
+        fail=1
+    fi
+
+    # 4. The fallback message includes the exact manual fix-it command
+    if ! grep -q "claude plugin marketplace update local-plugins" "$f"; then
+        echo "FAIL ${name}: fallback message missing the manual marketplace-update command"
+        fail=1
+    fi
+    if ! grep -q "claude plugin update ${name}@local-plugins" "$f"; then
+        echo "FAIL ${name}: fallback message missing the manual plugin-update command"
+        fail=1
+    fi
+
+    # 5. plugin update only runs when synced (not unconditionally after a failed sync)
+    if ! grep -qE '^\s*if synced\s*$' "$f"; then
+        echo "FAIL ${name}: plugin update is not gated on a successful marketplace sync"
+        fail=1
+    fi
+done
+
+if [ "$fail" -eq 0 ]; then
+    echo "PASS: all claude-plugin formulas retry+degrade the marketplace sync gracefully"
+    echo "  checked: $PLUGINS"
+fi
+exit "$fail"


### PR DESCRIPTION
## What

Fixes a spurious post_install failure discovered live during a craft `brew reinstall` (2026-07-02): `claude plugin marketplace update local-plugins` reported `Marketplace 'local-plugins' not found` even though the marketplace WAS correctly registered and the manifest had the right entry.

## Root cause

Step 3 of `post_install` (Claude Code registry sync) fires immediately after Step 2's `Process.waitpid` returns for the spawned install script. That script's marketplace-mirror write (`blocks/marketplace.sh`) isn't guaranteed visible to a freshly-spawned `claude` CLI process at that exact moment — a timing race, not a data problem.

**Live evidence gathered before writing the fix:**
- `manifest.json` had the correct `craft` entry (verified via `jq`)
- `claude plugin marketplace list` showed `local-plugins` registered
- Running the exact failing command standalone, 3x in a row, succeeded every time — ruling out a persistent config problem and confirming a transient race specific to the post_install subprocess context

## Fix

Retry the marketplace-update call once with a 1s delay; if both attempts fail, degrade to an advisory `opoo` with the exact manual fix-it command instead of a raw failed system-call trace. `plugin update` only runs once the sync has actually succeeded (previously it fired unconditionally right after the marketplace-update call, regardless of whether that call succeeded).

Change is in the Python generator template (`generator/generate.py`) — never hand-edited into the `.rb` files, per this repo's manifest-driven codegen convention. All 6 claude-plugin formulas (craft, himalaya-mcp, scholar, rforge, rforge-orchestrator, workflow) regenerated from the updated template.

## E2E evidence

```
$ ruby -c Formula/*.rb (all 6)          → Syntax OK
$ brew audit --strict data-wise/tap/*   → clean, 0 problems (all 6)
$ bash tests/test_no_symlink_install.sh → PASS (existing suite, all 6 checked)
$ bash tests/test_marketplace_sync_resilience.sh → PASS (new suite, all 6 checked)
```

**Positive control (planted defect):** reverted `craft.rb` to the old single-fire pattern, re-ran the new test — **5/5 checks correctly FAILED** ("no retry loop", "plugin update not gated on sync", etc.). Restored the fix, re-ran — back to PASS. Confirms the new test can actually catch this regression, not just decorate a passing state.

## Test plan

- [x] `ruby -c` on all 6 regenerated formulas
- [x] `brew audit --strict` on all 6 (clean)
- [x] Existing `test_no_symlink_install.sh` still green
- [x] New `test_marketplace_sync_resilience.sh` — green on the fix, red on a planted defect (positive control)
- [ ] CI green on this PR