### PR TITLE
fix(flow-cli): exclude r.1 man page to avoid link conflict with r formula

### DIFF
--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -15,8 +15,14 @@ class FlowCli < Formula
   depends_on "zsh"
 
   def install
-    # Man pages to proper Homebrew location
-    man1.install Dir["man/man1/*"] if (buildpath/"man/man1").exist?
+    # Man pages to proper Homebrew location. Exclude r.1: flow-cli's `r`
+    # dispatcher man page collides with the `r` formula's R.1 on
+    # case-insensitive filesystems (APFS default), which breaks `brew link`
+    # for anyone with both formulae installed.
+    if (buildpath/"man/man1").exist?
+      pages = Dir["man/man1/*"].reject { |f| File.basename(f).casecmp("r.1").zero? }
+      man1.install(*pages)
+    end
     rm_r(buildpath/"man") if (buildpath/"man").exist?
 
     # Core runtime files only (selective install)


### PR DESCRIPTION
## Summary

\`brew upgrade flow-cli\` currently fails at the link step: flow-cli's own `r.1` (man page for its `r` dispatcher) collides with the `r` formula's `R.1` on case-insensitive filesystems (APFS default, the macOS default). Reproduced locally:

```
Error: The `brew link` step did not complete successfully
Could not symlink share/man/man1/r.1
Target /opt/homebrew/share/man/man1/r.1
is a symlink belonging to r.
```

flow-cli 7.14.0 builds successfully but is left unlinked/inactive — a real update-blocking bug.

## Fix

Exclude `r.1` from the `man1.install` glob in `Formula/flow-cli.rb` (case-insensitive match). The `r` dispatcher itself is completely unaffected — only its Homebrew-installed man page is skipped when it would collide with the separate `r` (R language) formula.

## Test plan

- ✅ Ruby syntax valid (`ruby -c`)
- ✅ Filter logic verified against the real file list: excludes exactly `r.1` (23 → 22 files), no other man page affected
- ✅ Reproduced the original failure via `brew upgrade flow-cli` locally before writing the fix
- ⏳ Full `brew upgrade flow-cli` success needs to be re-verified after this merges and syncs to the local tap (Homebrew formulae can't be built/linked directly from a loose file outside a tap — "Homebrew requires formulae to be in a tap")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvJR434JKwmpq8LD458Aum