### PR TITLE
chore(rforge): bump formula + manifest to v2.19.0

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -3,10 +3,10 @@
 
 # Rforge formula for the data-wise/tap Homebrew tap.
 class Rforge < Formula
-  desc "R package ecosystem orchestrator — 41 commands — Claude Code plugin"
+  desc "R package ecosystem orchestrator — 42 commands — Claude Code plugin"
   homepage "https://github.com/Data-Wise/rforge"
-  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.18.0.tar.gz"
-  sha256 "7683de54d5aaa15f03490236ac5817f4c0f04e4858fd9dc8e7ca05cc53a6ffe2"
+  url "https://github.com/Data-Wise/rforge/archive/refs/tags/v2.19.0.tar.gz"
+  sha256 "d3f4cc1b43a3f6f3565b0ff28b6fc232ce3813812d8b3af3b1e693baef2ca980"
   license "MIT"
   head "https://github.com/Data-Wise/rforge.git", branch: "main"
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -218,12 +218,12 @@
     },
     "rforge": {
       "type": "claude-plugin",
-      "desc": "R package ecosystem orchestrator \u2014 41 commands \u2014 Claude Code plugin",
+      "desc": "R package ecosystem orchestrator \u2014 42 commands \u2014 Claude Code plugin",
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
-      "version": "2.18.0",
-      "sha256": "7683de54d5aaa15f03490236ac5817f4c0f04e4858fd9dc8e7ca05cc53a6ffe2",
+      "version": "2.19.0",
+      "sha256": "d3f4cc1b43a3f6f3565b0ff28b6fc232ce3813812d8b3af3b1e693baef2ca980",
       "head": "https://github.com/Data-Wise/rforge.git",
       "dependencies": {
         "runtime": [


### PR DESCRIPTION
Formula + manifest bump for rforge v2.19.0 (urlcheck triage + rhub bugfix + tidy audit, 42 commands).

- New tarball URL + sha256 (verified against the actual release asset)
- Command count 41→42
- `generator/generate.py rforge --diff` confirms formula/manifest agree (IDENTICAL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)