### PR TITLE
fix(rforge): sync stale command-count refs, adopt dynamic command_count

### DIFF
--- a/Formula/rforge.rb
+++ b/Formula/rforge.rb
@@ -117,9 +117,9 @@ class Rforge < Formula
           fi
 
           echo ""
-          echo "15 commands available:"
-          echo "  /rforge:analyze, /rforge:status, /rforge:deps, /rforge:cascade"
-          echo "  /rforge:release, /rforge:impact, /rforge:next, /rforge:complete"
+          echo "42 commands available:"
+          echo "  /rforge:analyze, /rforge:status, /rforge:health, /rforge:r:check"
+          echo "  /rforge:release, /rforge:next, /rforge:cascade, /rforge:r:test"
       else
           echo "⚠️  Automatic install failed (could not copy plugin files)."
           echo ""
@@ -231,7 +231,7 @@ class Rforge < Formula
       If not auto-enabled, run:
         claude plugin install rforge@local-plugins
 
-      35 commands for R package ecosystem management.
+      42 commands for R package ecosystem management.
 
       If the automatic copy failed (macOS permissions), run manually:
         mkdir -p ~/.claude/plugins/rforge && ( cd $(brew --prefix)/opt/rforge/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge && tar xf - )

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -225,6 +225,7 @@
       "version": "2.19.0",
       "sha256": "d3f4cc1b43a3f6f3565b0ff28b6fc232ce3813812d8b3af3b1e693baef2ca980",
       "head": "https://github.com/Data-Wise/rforge.git",
+      "command_count": 42,
       "dependencies": {
         "runtime": [
           "jq"
@@ -235,11 +236,14 @@
         "marketplace": true,
         "claude_detection": true
       },
+      "dynamic_counts": [
+        "commands"
+      ],
       "install_script_desc": "R package ecosystem orchestrator - analyze, test, release, cascade changes",
       "install_script_summary": [
-        "15 commands available:",
-        "  /rforge:analyze, /rforge:status, /rforge:deps, /rforge:cascade",
-        "  /rforge:release, /rforge:impact, /rforge:next, /rforge:complete"
+        "{command_count} commands available:",
+        "  /rforge:analyze, /rforge:status, /rforge:health, /rforge:r:check",
+        "  /rforge:release, /rforge:next, /rforge:cascade, /rforge:r:test"
       ],
       "test_paths": [
         {
@@ -255,7 +259,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "The RForge plugin has been installed to:\n  ~/.claude/plugins/rforge\n\nIf not auto-enabled, run:\n  claude plugin install rforge@local-plugins\n\n35 commands for R package ecosystem management.\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/rforge && ( cd $(brew --prefix)/opt/rforge/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge && tar xf - )"
+      "caveats_extra": "The RForge plugin has been installed to:\n  ~/.claude/plugins/rforge\n\nIf not auto-enabled, run:\n  claude plugin install rforge@local-plugins\n\n{command_count} commands for R package ecosystem management.\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/rforge && ( cd $(brew --prefix)/opt/rforge/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge && tar xf - )"
     },
     "rforge-orchestrator": {
       "type": "claude-plugin",


### PR DESCRIPTION
## Summary
- `Formula/rforge.rb`'s `caveats` said "35 commands" and the `post_install` summary said "15 commands available:" with a stale 8-command example list — both predated the current release process (rforge is at 42 commands as of v2.19.0) and had no mechanism keeping them current.
- Adds `command_count: 42` to the rforge entry in `generator/manifest.json` and templates it into `install_script_summary`/`caveats_extra` via `{command_count}`, matching the pattern craft's manifest entry already uses (`command_count` + `dynamic_counts` + token substitution in `generator/generate.py`'s `apply_command_count_token`). This means future rforge releases only need to bump one number in the manifest instead of hand-editing the generated formula in two places.
- Refreshed the stale example command list (`/rforge:deps`, `/rforge:impact`) to real current commands (`/rforge:health`, `/rforge:r:check`, `/rforge:r:test`).
- `desc` (already correct at "42 commands") is left as a plain literal, consistent with how craft's own `desc` field is handled (not templated — command_count only drives the two fields that were actually stale).

## Test plan
- [x] `python3 generator/generate.py rforge --diff` — shows only the intended 2-string diff before regenerating
- [x] `python3 generator/generate.py rforge` then `--diff` again → `IDENTICAL`
- [x] `ruby -c Formula/rforge.rb` → `Syntax OK`
- [x] `python3 -c "import json; json.load(open('generator/manifest.json'))"` → valid JSON

Not merging — leaving for review.