### PR TITLE
feat(folio): add manifest entry + generated placeholder formula

### DIFF
--- a/Formula/folio.rb
+++ b/Formula/folio.rb
@@ -1,0 +1,191 @@
+# typed: false
+# frozen_string_literal: true
+
+# Folio formula for the data-wise/tap Homebrew tap.
+class Folio < Formula
+  desc "Docs-authoring toolkit for Claude Code"
+  homepage "https://github.com/Data-Wise/folio"
+  url "https://github.com/Data-Wise/folio/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "MIT"
+
+  depends_on "jq"
+
+  def install
+    libexec.install Dir["*", ".*"].reject { |f| %w[. .. .git].include?(f) }
+
+    (bin/"folio-install").write <<~EOS
+      #!/bin/bash
+      # NOTE: Not using set -e to handle permission errors gracefully
+
+      PLUGIN_NAME="folio"
+      TARGET_DIR="$HOME/.claude/plugins/$PLUGIN_NAME"
+      # Copy from the stable opt path — Homebrew repoints opt/<name> across upgrades,
+      # and post_install re-runs this installer to refresh the real copy.
+      SOURCE_DIR="$(brew --prefix)/opt/folio/libexec"
+
+      echo "Installing Folio plugin to Claude Code..."
+
+      # Create plugins directory if it doesn't exist
+      mkdir -p "$HOME/.claude/plugins" 2>/dev/null || true
+
+      # Remove any existing installation. NOTE: older versions installed a SYMLINK
+      # here — we now install a REAL copy, so this also MIGRATES legacy symlink
+      # installs to a real directory.
+      if [ -L "$TARGET_DIR" ] || [ -d "$TARGET_DIR" ]; then
+          rm -rf "$TARGET_DIR" 2>/dev/null || rm -f "$TARGET_DIR" 2>/dev/null || true
+      fi
+
+      # Install a REAL copy of the Homebrew-managed files (never a symlink).
+      # Use a tar pipe rather than `cp -R`: tar copies symlinks AS symlinks, so the
+      # intentionally-broken governance test fixtures don't abort the copy on macOS
+      # BSD cp. LINK_SUCCESS gates the success/fallback branches below.
+      LINK_SUCCESS=false
+      if [ -d "$SOURCE_DIR" ] && mkdir -p "$TARGET_DIR" 2>/dev/null; then
+          if ( cd "$SOURCE_DIR" && tar cf - . ) 2>/dev/null | ( cd "$TARGET_DIR" && tar xf - ) 2>/dev/null; then
+              # Verify the copy actually landed before declaring success
+              if [ -f "$TARGET_DIR/.claude-plugin/plugin.json" ]; then
+                  LINK_SUCCESS=true
+              fi
+          fi
+          [ "$LINK_SUCCESS" = true ] || rm -rf "$TARGET_DIR" 2>/dev/null || true
+      fi
+
+      if [ "$LINK_SUCCESS" = true ]; then
+
+          echo "✅ Folio plugin installed successfully!"
+
+          # Register plugin in Claude Code if not already installed
+          if [ "$CLAUDE_RUNNING" = false ] && command -v claude &>/dev/null; then
+              if ! claude plugin list 2>/dev/null | grep -q "folio@local-plugins"; then
+                  claude plugin install "folio@local-plugins" 2>/dev/null || true
+              fi
+          fi
+
+          echo ""
+          if [ "$AUTO_ENABLED" = true ]; then
+              echo "Plugin auto-enabled in Claude Code."
+          elif [ "$CLAUDE_RUNNING" = true ]; then
+              echo "Claude Code is running - skipped auto-enable to avoid conflicts."
+              echo "After restarting Claude Code, the folio plugin will be available."
+          fi
+
+          echo ""
+          echo "0 commands available:"
+          echo "  /folio:hub, /folio:do, /folio:docs:tutorial, /folio:docs:guide, ..."
+      else
+          echo "⚠️  Automatic install failed (could not copy plugin files)."
+          echo ""
+          echo "Copy the plugin into place manually to complete installation:"
+          echo ""
+          echo "  mkdir -p $TARGET_DIR && ( cd $SOURCE_DIR && tar cf - . ) | ( cd $TARGET_DIR && tar xf - )"
+          echo ""
+          exit 0  # Don't fail the brew install
+      fi
+
+    EOS
+
+    (bin/"folio-uninstall").write <<~EOS
+      #!/bin/bash
+      set -e
+
+      PLUGIN_NAME="folio"
+      TARGET_DIR="$HOME/.claude/plugins/$PLUGIN_NAME"
+
+      if [ -L "$TARGET_DIR" ] || [ -d "$TARGET_DIR" ]; then
+          rm -rf "$TARGET_DIR"
+          echo "✅ Folio plugin uninstalled"
+      else
+          echo "Plugin not found at $TARGET_DIR"
+      fi
+
+    EOS
+
+    chmod "+x", bin/"folio-install"
+    chmod "+x", bin/"folio-uninstall"
+  end
+
+  def post_install
+    # Step 1: Auto-install plugin with 30s timeout
+    begin
+      require "timeout"
+      pid = Process.spawn(bin/"folio-install")
+      Timeout.timeout(30) { Process.waitpid(pid) }
+    rescue Timeout::Error
+      begin
+        Process.kill("TERM", pid)
+      rescue
+        nil
+      end
+      begin
+        Process.waitpid(pid)
+      rescue
+        nil
+      end
+      opoo "folio-install timed out after 30 seconds (skipping)"
+    rescue
+      nil
+    end
+
+    # Step 2: Sync Claude Code plugin registry (optional)
+    begin
+      if which("claude")
+        synced = false
+        2.times do |attempt|
+          synced = system("claude", "plugin", "marketplace", "update", "local-plugins")
+          break if synced
+
+          sleep 1 if attempt.zero?
+        end
+        if synced
+          system "claude", "plugin", "install", "folio@local-plugins"
+        else
+          opoo "marketplace sync didn't settle in time - run: " \
+               "claude plugin marketplace update local-plugins && " \
+               "claude plugin update folio@local-plugins"
+        end
+      else
+        opoo "claude not on PATH - run: claude plugin install folio@local-plugins to finish"
+      end
+    rescue
+      nil
+    end
+
+    # Prune old cached plugin versions (keep newest 3)
+    begin
+      cache = Pathname.new("#{Dir.home}/.claude/plugins/cache/local-plugins/folio")
+      cache.children.select(&:directory?).sort_by(&:mtime).reverse.drop(3).each(&:rmtree) if cache.directory?
+    rescue
+      nil
+    end
+
+    # Warn if the installed copy's version drifts from this formula
+    begin
+      require "json"
+      installed = Pathname.new("#{Dir.home}/.claude/plugins/folio/.claude-plugin/plugin.json")
+      if installed.file?
+        iv = JSON.parse(installed.read)["version"]
+        opoo "installed folio v#{iv} != formula v#{version}" if iv && iv.to_s != version.to_s
+      end
+    rescue
+      nil
+    end
+  end
+
+  def post_uninstall
+    system bin/"folio-uninstall" if (bin/"folio-uninstall").exist?
+  end
+
+  def caveats
+    <<~EOS
+      The Folio plugin has been installed to:
+        ~/.claude/plugins/folio
+
+      For more information:
+        https://github.com/Data-Wise/folio
+    EOS
+  end
+
+  test do
+  end
+end

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -218,7 +218,7 @@
     },
     "rforge": {
       "type": "claude-plugin",
-      "desc": "R package ecosystem orchestrator \u2014 42 commands \u2014 Claude Code plugin",
+      "desc": "R package ecosystem orchestrator — 42 commands — Claude Code plugin",
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
@@ -310,7 +310,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "\u26a0\ufe0f  DEPRECATED \u2014 This formula is no longer maintained.\n\nThe plugin has been renamed to `rforge` and now lives in its own\nrepository. Migrate with:\n\n    brew uninstall data-wise/tap/rforge-orchestrator\n    rm -rf ~/.claude/plugins/rforge-orchestrator\n    brew install --HEAD data-wise/tap/rforge\n\nThe new formula installs to ~/.claude/plugins/rforge and ships\nv1.2.0 features (R-aware PreToolUse hook, marketplace install,\nvalidation skills, 15 commands).\n\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nLegacy install info (for users on this deprecated formula):\n\nThe RForge Orchestrator plugin has been installed to:\n  ~/.claude/plugins/rforge-orchestrator\n\nIf not auto-enabled, run:\n  claude plugin install rforge-orchestrator@local-plugins\n\nRequirements:\n  - Claude Code CLI must be installed\n  - RForge MCP server must be configured in ~/.claude/settings.json\n\nAvailable commands (v0.1.0 had only these three):\n  /rforge:analyze  - Analyze R project and recommend tools\n  /rforge:quick    - Quick project analysis\n  /rforge:thorough - Thorough multi-stage analysis\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/rforge-orchestrator && ( cd $(brew --prefix)/opt/rforge-orchestrator/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge-orchestrator && tar xf - )\n\nFor the new plugin and full v1.2.0 docs:\n  https://github.com/Data-Wise/rforge"
+      "caveats_extra": "⚠️  DEPRECATED — This formula is no longer maintained.\n\nThe plugin has been renamed to `rforge` and now lives in its own\nrepository. Migrate with:\n\n    brew uninstall data-wise/tap/rforge-orchestrator\n    rm -rf ~/.claude/plugins/rforge-orchestrator\n    brew install --HEAD data-wise/tap/rforge\n\nThe new formula installs to ~/.claude/plugins/rforge and ships\nv1.2.0 features (R-aware PreToolUse hook, marketplace install,\nvalidation skills, 15 commands).\n\n──────────────────────────────────────────────────────\n\nLegacy install info (for users on this deprecated formula):\n\nThe RForge Orchestrator plugin has been installed to:\n  ~/.claude/plugins/rforge-orchestrator\n\nIf not auto-enabled, run:\n  claude plugin install rforge-orchestrator@local-plugins\n\nRequirements:\n  - Claude Code CLI must be installed\n  - RForge MCP server must be configured in ~/.claude/settings.json\n\nAvailable commands (v0.1.0 had only these three):\n  /rforge:analyze  - Analyze R project and recommend tools\n  /rforge:quick    - Quick project analysis\n  /rforge:thorough - Thorough multi-stage analysis\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/rforge-orchestrator && ( cd $(brew --prefix)/opt/rforge-orchestrator/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge-orchestrator && tar xf - )\n\nFor the new plugin and full v1.2.0 docs:\n  https://github.com/Data-Wise/rforge"
     },
     "workflow": {
       "type": "claude-plugin",
@@ -447,6 +447,32 @@
       "version": "0.3.0",
       "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
       "generated": false
+    },
+    "folio": {
+      "type": "claude-plugin",
+      "desc": "Docs-authoring toolkit for Claude Code",
+      "homepage": "https://github.com/Data-Wise/folio",
+      "source": "github",
+      "repo": "Data-Wise/folio",
+      "version": "0.1.0",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "command_count": 0,
+      "dependencies": {
+        "runtime": [
+          "jq"
+        ]
+      },
+      "dynamic_counts": [
+        "commands",
+        "agents",
+        "skills"
+      ],
+      "install_script_desc": "Docs-authoring toolkit - tutorials, guides, API docs, mermaid, site management",
+      "install_script_summary": [
+        "{command_count} commands available:",
+        "  /folio:hub, /folio:do, /folio:docs:tutorial, /folio:docs:guide, ..."
+      ],
+      "_placeholder_note": "sha256/version/command_count are PLACEHOLDERS - real values land when folio v1.0.0 releases (homebrew-release.yml regenerates). DO NOT publish this formula before then."
     }
   }
 }


### PR DESCRIPTION
## Summary

folio's v1.0.0 release automation (`homebrew-release.yml` in `Data-Wise/folio`) failed with
`KeyError: 'folio'` — the manifest entry for it was created back in T1.5 but only ever landed on
a local, unpushed `feature/folio-formula` branch in this repo, never merged to `main`.

That branch also carries an unrelated regression if merged wholesale — `rforge` pinned back to
v2.18.0/35 commands (stale relative to current `main`'s v2.19.0/42). This PR cherry-picks just
the `folio` manifest entry instead of merging that branch.

- `generator/manifest.json`: new `"folio"` entry, placeholder version/sha256/command_count (real
  values land via `homebrew-release.yml`'s automated regeneration on the actual release run —
  same pattern every other formula here uses)
- `Formula/folio.rb`: generated via `python3 generator/generate.py folio`, not hand-written

## Test plan
- [x] `ruby -c Formula/folio.rb` — syntax OK
- [x] `generator/check-drift.sh` — zero drift, all 15 existing formulas untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)