### PR TITLE
fix(folio): add test_paths, close empty brew audit test block

### DIFF
--- a/Formula/folio.rb
+++ b/Formula/folio.rb
@@ -187,5 +187,7 @@ class Folio < Formula
   end
 
   test do
+    assert_path_exists libexec/".claude-plugin/plugin.json"
+    assert_predicate libexec/"commands", :directory?
   end
 end

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -471,6 +471,16 @@
       "install_script_summary": [
         "{command_count} commands available:",
         "  /folio:hub, /folio:do, /folio:docs:tutorial, /folio:docs:guide, ..."
+      ],
+      "test_paths": [
+        {
+          "path": ".claude-plugin/plugin.json",
+          "type": "file"
+        },
+        {
+          "path": "commands",
+          "type": "directory"
+        }
       ]
     }
   }


### PR DESCRIPTION
## Summary
- \`brew audit --formula data-wise/tap/folio\` (run as part of T4.3's own acceptance criteria) flagged: \`test do\` should not be empty.
- Root cause: PR #141's folio manifest entry omitted \`test_paths\`, unlike every sibling formula (e.g. rforge). The generator silently emits an empty \`test do...end\` block when the key is absent.

## Change
Adds a minimal \`test_paths\` (plugin.json file + commands directory, matching rforge's pattern) and regenerates \`Formula/folio.rb\` via \`python3 generator/generate.py folio\`.

## Verification
- \`brew audit --formula\` locally: clean (0 problems) after regen
- \`ruby -c Formula/folio.rb\`: syntax OK
- \`generator/check-drift.sh\`: zero drift after commit

## Test plan
- [ ] CI green