### PR TITLE
fix(folio): add missing marketplace + claude_detection features to manifest

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -1,10 +1,24 @@
 status: Active
-last_session: 2026-07-02
+last_session: 2026-07-16
 milestone: Homebrew refactor complete
 
 progress: All phases merged to main, repo cleaned up, CI verified
 
-<<<<<<< Updated upstream
+📋 Session 2026-07-16 (folio-install silent registration failure fix):
+- PR #143 (feature/fix-folio-install-registration, open): folio's
+  `generator/manifest.json` entry had no `"features"` key at all, so
+  `generate.py` silently omitted both the marketplace.json-mirroring block
+  and the `CLAUDE_RUNNING` detection block from `Formula/folio.rb` — `brew
+  install` reported success but never registered folio with Claude Code
+  (Data-Wise/folio#18). Fix: added `features.marketplace` +
+  `features.claude_detection` to folio's manifest entry, regenerated
+  `Formula/folio.rb` (not hand-edited) — `--diff` confirmed all other 6
+  formulas byte-identical. Added `tests/test_manifest_required_features.sh`
+  as a structural guard (verified red against the pre-fix manifest, green
+  after); documented the required-flags convention in CLAUDE.md's Formula
+  Generator section (same doc gap that let this ship unnoticed).
+- Spec: folio repo's `docs/specs/SPEC-fix-install-registration-2026-07-16.md`.
+
 📋 Session 2026-07-02 (post_install marketplace-sync race fix):
 - PR #134 (main, merged): post_install Step 3 (`claude plugin marketplace update
   local-plugins`) fired immediately after Step 2's `Process.waitpid` returned,
@@ -29,13 +43,12 @@ progress: All phases merged to main, repo cleaned up, CI verified
   switched to `main`, pulled, confirmed 0 unmerged work lost.
 - Worktree `feature-post-install-marketplace-resilience` created and removed
   same session (merged, no orphan left).
-=======
+
 📋 Session 2026-07-02 (flow-cli man-page collision fix):
 - Fixed `flow-cli.rb` man-page install: unconditionally excludes `r.1` (flow-cli's `r`-dispatcher man page collided with the `r` (R-language) formula's `R.1` on case-insensitive filesystems, breaking `brew link` for anyone with both installed) — PR #135 (main 05a2e17)
 - Verified via `brew reinstall flow-cli`: clean install, 0 errors, `r.1` correctly absent from flow-cli's Cellar, `r` formula's own man page untouched
 - Worktree `fix/flow-cli-r-man-conflict` removed, branch deleted (squash-merged)
 - Tradeoff: flow-cli's `r`-dispatcher man page is no longer installed via Homebrew at all (unconditional exclusion, not conditional-on-collision) — dispatcher itself unaffected, only `man r` via brew
->>>>>>> Stashed changes
 
 📋 Session 2026-06-10 (depends_on macos deprecation fix):
 - Fixed `depends_on macos:` deprecation in scribe + scribe-dev casks (string form `">= :catalina"` → bare symbol `:catalina`) — PR #112 (main c3e2e38)
@@ -66,6 +79,7 @@ progress: All phases merged to main, repo cleaned up, CI verified
 | rforge | plugin (generated) | No | CLEAN (stable 1.2.0, 2026-05-10) |
 | rforge-orchestrator | plugin (legacy) | Yes | DEPRECATED 2026-05-10 → migrate to `rforge` |
 | workflow | plugin (generated) | Yes | CLEAN |
+| folio | plugin (generated) | Yes | CLEAN (registration fix PR #143 pending merge) |
 | aiterm | python | Yes | CLEAN |
 | atlas | node | Yes | CLEAN |
 | nexus-cli | python | Yes | CLEAN |
@@ -75,6 +89,7 @@ progress: All phases merged to main, repo cleaned up, CI verified
 | scribe-cli | swift | No | CLEAN (placeholder SHA) |
 
 🎯 Next Action:
+→ Get PR #143 (folio registration fix) reviewed/merged; comment back on folio#18 once merged
 → Replace scribe-cli placeholder SHA when v0.3.0 release is created
 → Verify update-formula workflow uses App token correctly (next time a project releases)
 → Monitor: push-trigger suppression may need further investigation (PR #94 fix didn't fully resolve)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,17 +68,19 @@ mkdocs build --strict     # Build and validate
 
 ## Formula Generator
 
-6 plugin formulas are generated from `generator/manifest.json`. The generator owns structure; CI owns version/SHA. Key manifest fields include `libexec_copy_map` for directory layout, `extra_scripts` for CLI wrappers, and feature flags for schema cleanup and branch guards.
+7 plugin formulas are generated from `generator/manifest.json`. The generator owns structure; CI owns version/SHA. Key manifest fields include `libexec_copy_map` for directory layout, `extra_scripts` for CLI wrappers, and a `features` object gating optional install-script blocks (`schema_cleanup`, `branch_guard`, `marketplace`, `claude_detection`).
+
+**`features.marketplace` and `features.claude_detection` are required for every `claude-plugin` entry**, not optional extras — omitting either silently drops the corresponding install-script block with no error at generate- or install-time (folio#18: a new entry shipped with no `features` key at all, so `brew install` reported success but never registered the plugin with Claude Code). `tests/test_manifest_required_features.sh` gates this in CI.
 
 ```bash
-python3 generator/generate.py              # Generate all 6 plugin formulas
+python3 generator/generate.py              # Generate all 7 plugin formulas
 python3 generator/generate.py craft        # Generate one formula
 python3 generator/generate.py --diff       # Diff vs existing (no overwrite)
 python3 generator/generate.py --validate   # Validate output with ruby -c
 python3 generator/generate.py --list       # List all formulas in manifest
 ```
 
-Generated formulas: craft, himalaya-mcp, scholar, rforge, rforge-orchestrator, workflow. The other 8 are hand-crafted (different enough to not benefit from generation).
+Generated formulas: craft, himalaya-mcp, scholar, rforge, rforge-orchestrator, workflow, folio. The other 8 are hand-crafted (different enough to not benefit from generation).
 
 When editing a plugin formula, edit `manifest.json` + `blocks/` then regenerate — do NOT edit the generated `.rb` directly.
 

--- a/Formula/folio.rb
+++ b/Formula/folio.rb
@@ -52,6 +52,51 @@ class Folio < Formula
       fi
 
       if [ "$LINK_SUCCESS" = true ]; then
+          # Mirror into local-marketplace for plugin discovery — a REAL copy, not a
+          # symlink (also migrates a legacy symlink here). Costs ~2x disk per plugin;
+          # accepted tradeoff for the no-symlinks install policy.
+          MARKETPLACE_DIR="$HOME/.claude/local-marketplace"
+          mkdir -p "$MARKETPLACE_DIR" 2>/dev/null || true
+          if [ -d "$TARGET_DIR" ]; then
+              rm -rf "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || rm -f "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              mkdir -p "$MARKETPLACE_DIR/$PLUGIN_NAME" 2>/dev/null || true
+              ( cd "$TARGET_DIR" && tar cf - . ) 2>/dev/null | ( cd "$MARKETPLACE_DIR/$PLUGIN_NAME" && tar xf - ) 2>/dev/null || true
+          fi
+
+          # Add to marketplace.json manifest (required for 'claude plugin install' discovery)
+          MANIFEST_FILE="$MARKETPLACE_DIR/.claude-plugin/marketplace.json"
+          PLUGIN_DESC="Docs-authoring toolkit - tutorials, guides, API docs, mermaid, site management"
+          if command -v jq &>/dev/null && [ -f "$MANIFEST_FILE" ]; then
+              # Check if plugin already exists in manifest
+              if ! jq -e --arg name "$PLUGIN_NAME" '.plugins[] | select(.name == $name)' "$MANIFEST_FILE" >/dev/null 2>&1; then
+                  TEMP_FILE=$(mktemp)
+                  if jq --arg name "$PLUGIN_NAME" --arg desc "$PLUGIN_DESC" \
+                      '.plugins = [{"name": $name, "source": ("./"+$name), "description": $desc}] + .plugins' \
+                      "$MANIFEST_FILE" > "$TEMP_FILE" 2>/dev/null; then
+                      mv "$TEMP_FILE" "$MANIFEST_FILE"
+                  else
+                      rm -f "$TEMP_FILE" 2>/dev/null
+                  fi
+              fi
+          fi
+
+          # Try to auto-enable via jq if available
+          # Skip if Claude Code is running (holds file locks that can block mv)
+          SETTINGS_FILE="$HOME/.claude/settings.json"
+          AUTO_ENABLED=false
+          CLAUDE_RUNNING=false
+
+          if pgrep -x "claude" >/dev/null 2>&1; then
+              CLAUDE_RUNNING=true
+          fi
+
+          if [ "$CLAUDE_RUNNING" = false ] && command -v jq &>/dev/null && [ -f "$SETTINGS_FILE" ]; then
+              TEMP_FILE=$(mktemp)
+              if jq --arg plugin "${PLUGIN_NAME}@local-plugins" '.enabledPlugins[$plugin] = true' "$SETTINGS_FILE" > "$TEMP_FILE" 2>/dev/null; then
+                  mv "$TEMP_FILE" "$SETTINGS_FILE" 2>/dev/null && AUTO_ENABLED=true
+              fi
+              [ -f "$TEMP_FILE" ] && rm -f "$TEMP_FILE" 2>/dev/null
+          fi
 
           echo "✅ Folio plugin installed successfully!"
 

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -462,6 +462,10 @@
           "jq"
         ]
       },
+      "features": {
+        "marketplace": true,
+        "claude_detection": true
+      },
       "dynamic_counts": [
         "commands",
         "agents",

--- a/tests/test_manifest_required_features.sh
+++ b/tests/test_manifest_required_features.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Contract: every generated claude-plugin manifest entry declares
+# features.marketplace and features.claude_detection.
+#
+# Root cause (folio#18): folio's manifest entry shipped with no "features"
+# key at all, so generate.py silently omitted both the marketplace-mirror
+# block and the CLAUDE_RUNNING detection block — brew install "succeeded"
+# but never registered the plugin with Claude Code, with no error anywhere.
+# This test is the structural guard against the next new plugin shipping
+# the same way.
+#
+# Scope: all claude-plugin, generated=true manifest entries.
+
+set -u
+cd "$(dirname "$0")/.." || exit 2
+
+fail=0
+
+result=$(python3 -c "
+import json
+m = json.load(open('generator/manifest.json'))
+bad = []
+for name, c in m['formulas'].items():
+    if c.get('type') != 'claude-plugin' or not c.get('generated', True):
+        continue
+    features = c.get('features') or {}
+    missing = [
+        flag for flag in ('marketplace', 'claude_detection')
+        if not features.get(flag)
+    ]
+    if missing:
+        bad.append((name, missing))
+for name, missing in bad:
+    print(f'{name}: missing {missing}')
+")
+
+if [ -n "$result" ]; then
+    echo "FAIL: claude-plugin formulas missing required manifest features:"
+    echo "$result"
+    fail=1
+else
+    echo "PASS: every generated claude-plugin manifest entry declares marketplace + claude_detection features"
+fi
+
+exit "$fail"


### PR DESCRIPTION
## Summary
- folio's `generator/manifest.json` entry had no `"features"` key at all, so `generate.py` silently omitted both the marketplace.json-mirroring block and the `CLAUDE_RUNNING` detection block from `Formula/folio.rb`
- `brew install` reported success but never registered folio with Claude Code — no marketplace entry was added, and the existing registration call (`claude plugin install folio@local-plugins`) was unreachable dead code since `$CLAUDE_RUNNING` was never set
- Adds `features.marketplace` + `features.claude_detection` to folio's manifest entry, matching every other working formula (craft, rforge, etc.)
- Regenerates `Formula/folio.rb` via the generator (not hand-edited) — `--diff` confirms every other formula is byte-identical
- Adds `tests/test_manifest_required_features.sh` as a structural guard against the next new plugin shipping the same silent gap

Fixes Data-Wise/folio#18

Spec: [folio's docs/specs/SPEC-fix-install-registration-2026-07-16.md](https://github.com/Data-Wise/folio/blob/dev/docs/specs/SPEC-fix-install-registration-2026-07-16.md)

## Test plan
- [x] `python3 generator/generate.py --diff --validate` — only `folio.rb` differs; all other 6 formulas byte-identical, syntax OK
- [x] New test run against pre-fix manifest (`git show HEAD~1:generator/manifest.json`) → **FAILS** (`folio: missing ['marketplace', 'claude_detection']`), proving it would have caught #18
- [x] Same test against the fix → **PASSES**
- [x] Full existing suite (`test_craft_install_timeout.sh`, `test_marketplace_sync_resilience.sh`, `test_no_symlink_install.sh`) — all green; `folio` now also appears in the marketplace-sync-resilience test's checked list (previously excluded since it lacked the flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)