### PR TITLE
fix(atlas): drop stale node@20 dependency pin

### DIFF
--- a/Formula/atlas.rb
+++ b/Formula/atlas.rb
@@ -10,7 +10,7 @@ class Atlas < Formula
   license "MIT"
 
   depends_on "python@3.12" => :build
-  depends_on "node@20" # Required for node-gyp (better-sqlite3)
+  depends_on "node"
 
   def install
     system "npm", "install", *std_npm_args


### PR DESCRIPTION
Replaces #144 (rebased onto main after the homebrew-release bot's v0.13.1 url/sha256 bump landed, to avoid conflict).

`brew info data-wise/tap/atlas` reports "Recursive Runtime (8): 7 installed, 1 missing" — traced to `depends_on "node@20"`, a keg-only formula nobody has installed. Root cause: atlas's `bin/atlas.js` shebang is `#!/usr/bin/env node` (version-agnostic) — it never actually invokes the pinned node@20 binary, it just uses whatever `node` resolves to on PATH. The pin predates atlas's own Node 26 support (added v0.12.1) and was never updated.

Every other Node formula in this tap (`examark`, `himalaya-mcp`, `mcp-bridge`) already uses the unversioned `node` — this brings atlas in line.

## Test plan
- `brew style Formula/atlas.rb` → clean, 0 offenses
- `brew audit --strict --online data-wise/tap/atlas` → clean, no output
- Verified locally: atlas is currently installed and working against `node@26.5.0` (not node@20), confirming the runtime is genuinely version-agnostic.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>