### PR TITLE
fix(folio): bump revision so brew upgrade detects the #143 install-script fix

### DIFF
--- a/Formula/folio.rb
+++ b/Formula/folio.rb
@@ -8,6 +8,7 @@ class Folio < Formula
   url "https://github.com/Data-Wise/folio/archive/refs/tags/v1.0.0.tar.gz"
   sha256 "d0cb30e26ba620a78fc3da3737102407816b9a1b7331d9156a0e1a6c996255cb"
   license "MIT"
+  revision 1
 
   depends_on "jq"
 

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -215,6 +215,12 @@ def generate_formula(formula_name, config, defaults):
         if "head" in config:
             lines.append(f'  head "{config["head"]}", branch: "main"')
 
+        # Revision — bump when install-script/post_install logic changes with no
+        # version change, so `brew upgrade` detects it (plain content edits are
+        # otherwise invisible to upgrade's version-only comparison).
+        if config.get("revision"):
+            lines.append(f'  revision {config["revision"]}')
+
     # deprecate! directive — after license/head (matches Homebrew convention)
     # Emits a blank line before deprecate! to match standard formatting
     if "deprecate" in config:

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -456,6 +456,7 @@
       "repo": "Data-Wise/folio",
       "version": "1.0.0",
       "sha256": "d0cb30e26ba620a78fc3da3737102407816b9a1b7331d9156a0e1a6c996255cb",
+      "revision": 1,
       "command_count": 17,
       "dependencies": {
         "runtime": [


### PR DESCRIPTION
## Summary
- PR #143 fixed folio's silent registration failure but never bumped version/revision — `brew upgrade` only compares version+revision against the installed receipt, so anyone already on folio 1.0.0 would never get the fix via `brew upgrade`, only via an explicit `brew reinstall`
- Adds generator support for an optional `revision` manifest field (emitted as `revision N` after `license`, standard Homebrew placement)
- Sets `revision: 1` on folio's manifest entry, retroactively covering #143's unversioned change
- Regenerates `Formula/folio.rb` (not hand-edited) — `--diff` confirms all 6 other formulas byte-identical

## Test plan
- [x] `python3 generator/generate.py --diff --validate` — only `folio.rb` differs (one line: `revision 1`), all other formulas byte-identical, syntax OK
- [x] **Live verification**: copied the regenerated formula into the local tap checkout (`$(brew --repository data-wise/tap)`) — `brew outdated` correctly reports folio (`1.0.0 → stable 1.0.0`), confirming `brew upgrade` would now pick this up. Reverted the test copy before committing (verified byte-identical restore) — no local tap state was left modified.
- [x] Full existing suite (`test_manifest_required_features.sh`, `test_marketplace_sync_resilience.sh`, `test_no_symlink_install.sh`) — all green, folio included in all three

Related: #143, #145. The separate marketplace-sync retry-timing issue observed during manual reinstall testing is being tracked in a different session — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)