### PR TITLE
chore(craft): bump formula to v4.1.0

### DIFF
--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -3,10 +3,10 @@
 
 # Craft formula for the data-wise/tap Homebrew tap.
 class Craft < Formula
-  desc "Full-stack developer toolkit for Claude Code with 47 commands"
+  desc "Full-stack developer toolkit for Claude Code with 48 commands"
   homepage "https://github.com/Data-Wise/craft"
-  url "https://github.com/Data-Wise/craft/archive/refs/tags/v4.0.0.tar.gz"
-  sha256 "3397b679c3372d409dd3512f0f2e0035c731b947dc88be3665e23668d47eaf1a"
+  url "https://github.com/Data-Wise/craft/archive/refs/tags/v4.1.0.tar.gz"
+  sha256 "071d4f9eab555994172efdd5cca2312d89ccf65caf3bba109903baceedb5018f"
   license "MIT"
 
   depends_on "jq"
@@ -164,7 +164,7 @@ class Craft < Formula
               echo "Branch guard hook installed (protects main/dev branches)."
           fi
           echo ""
-          echo "47 commands available:"
+          echo "48 commands available:"
           echo "  /craft:do, /craft:orchestrate, /brainstorm, /craft:check"
           echo "  Categories: arch, ci, code, dist, docs, git, plan, site, test, workflow"
       else
@@ -286,7 +286,7 @@ class Craft < Formula
 
   def caveats
     <<~EOS
-      47 commands for full-stack development:
+      48 commands for full-stack development:
         - Architecture & planning
         - Code generation & refactoring
         - Testing & CI/CD

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -6,13 +6,13 @@
   "formulas": {
     "craft": {
       "type": "claude-plugin",
-      "desc": "Full-stack developer toolkit for Claude Code with 47 commands",
+      "desc": "Full-stack developer toolkit for Claude Code with 48 commands",
       "homepage": "https://github.com/Data-Wise/craft",
       "source": "github",
       "repo": "Data-Wise/craft",
-      "version": "4.0.0",
-      "sha256": "3397b679c3372d409dd3512f0f2e0035c731b947dc88be3665e23668d47eaf1a",
-      "command_count": 47,
+      "version": "4.1.0",
+      "sha256": "071d4f9eab555994172efdd5cca2312d89ccf65caf3bba109903baceedb5018f",
+      "command_count": 48,
       "dependencies": {
         "runtime": [
           "jq"


### PR DESCRIPTION
## Summary
- Bumps craft formula 4.0.0 -> 4.1.0 (47 -> 48 commands)
- Craft v4.1.0 adds `/craft:restore` and fixes the `/craft:refine` confirm-flow bug (see Data-Wise/craft release notes for v4.1.0)
- Manifest-driven: only `generator/manifest.json` hand-edited, `Formula/craft.rb` regenerated via `python3 generator/generate.py`

## Test plan
- [x] `brew style Formula/craft.rb` — clean
- [x] `brew audit --strict data-wise/tap/craft` (formula copied into local tap clone) — clean
- [x] `brew install data-wise/tap/craft` — succeeds, reports 48 commands available