### PR TITLE
docs(site): fix stale counts, obsolete install-mechanism description, missing folio entry

### DIFF
--- a/docs/formulas/plugins.md
+++ b/docs/formulas/plugins.md
@@ -16,8 +16,8 @@ flowchart TD
     D --> E{"`**Claude running?**
     pgrep -x claude`"}
     E -->|No| F["`**Auto-enable**
-    Symlink + marketplace + settings.json`"]
-    E -->|Yes| G["`**Symlink only**
+    Real copy + marketplace + settings.json`"]
+    E -->|Yes| G["`**Copy only**
     Skip settings.json modification`"]
     F --> H["`**Ready to use**
     Plugin active in Claude Code`"]
@@ -26,13 +26,17 @@ flowchart TD
 
 ## Install Pattern
 
-All 6 plugin formulas share these features:
+All 7 plugin formulas share these features:
 
-### Symlink Creation (3 fallback methods)
+### Real-Copy Install (no symlinks)
 
-1. `ln -sfh` (atomic, prevents circular symlinks)
-2. `ln -sf` (standard)
-3. `rm -f && ln -s` (force recreate)
+Installs a **real copy** of the Homebrew-managed files via a `tar` pipe (`tar cf - . | tar xf -`),
+never a symlink — this also migrates any pre-existing symlink install (from older formula
+versions) to a real directory on the next `brew reinstall`/`brew upgrade`. `tar` is used instead
+of `cp -R` because it copies symlinks *as* symlinks rather than following them, which matters for
+test fixtures containing intentionally-broken symlinks. The copy is verified (checks
+`.claude-plugin/plugin.json` landed) before being declared successful; the marketplace mirror
+step (below) uses the same tar-pipe pattern.
 
 ### Schema Cleanup
 
@@ -43,8 +47,9 @@ Strips unrecognized keys from `plugin.json` (e.g., `claude_md_budget`). Dual def
 
 ### Marketplace Registration
 
-- Creates symlink in `~/.claude/local-marketplace/`
-- Adds entry to `marketplace.json` via `jq`
+- Mirrors a real copy into `~/.claude/local-marketplace/<name>/` (same tar-pipe pattern as the
+  install step, not a symlink)
+- Adds entry to `marketplace.json` via `jq` (gated on `features.marketplace`)
 - Auto-enables plugin in `settings.json`
 
 ### Claude Detection
@@ -116,3 +121,14 @@ ADHD-friendly workflow automation plugin.
 ```bash
 brew install data-wise/tap/workflow
 ```
+
+### folio
+
+Docs-authoring toolkit — tutorials, guides, API docs, mermaid diagrams, doc health checks, and
+site management. 17 commands, 6 agents, 6 skills.
+
+```bash
+brew install data-wise/tap/folio
+```
+
+Site: [data-wise.github.io/folio](https://data-wise.github.io/folio/).

--- a/docs/generator/index.md
+++ b/docs/generator/index.md
@@ -7,12 +7,12 @@ The generator produces consistent Ruby formulas for Claude Code plugins from a s
 ```mermaid
 flowchart LR
     M["`**manifest.json**
-    14 formula entries`"] --> G["`**generate.py**
+    16 formula entries`"] --> G["`**generate.py**
     Python 3, stdlib only`"]
     B["`**blocks/**
     Composable bash fragments`"] --> G
     G --> F["`**Formula/*.rb**
-    6 plugin formulas`"]
+    7 plugin formulas`"]
 ```
 
 ## Ownership Model
@@ -26,7 +26,7 @@ flowchart LR
 ## Usage
 
 ```bash
-# Generate all 6 plugin formulas
+# Generate all 7 plugin formulas
 python3 generator/generate.py
 
 # Generate a specific formula
@@ -52,10 +52,11 @@ python3 generator/generate.py --list
 | rforge | Head-only (no releases) |
 | rforge-orchestrator | Monorepo URL pattern |
 | workflow | Monorepo tarball URL |
+| folio | Standard plugin pattern, `revision`-tracked |
 
 All generated plugin formulas use a 3-step `post_install` pattern: (1) JSON schema cleanup, (2) auto-install with 30s timeout, (3) registry sync — each in its own `begin/rescue/end` block.
 
-The other 8 formulas are hand-crafted (Python virtualenv, Node npm, Shell, Swift patterns that differ enough from the plugin template).
+The other 9 formulas are hand-crafted (Python virtualenv, Node npm, Shell, Swift patterns that differ enough from the plugin template).
 
 !!! warning "Edit the manifest, not the .rb"
     When modifying a plugin formula, edit `manifest.json` + `blocks/` then regenerate. Do not edit the generated `.rb` directly — changes will be overwritten.

--- a/docs/generator/manifest.md
+++ b/docs/generator/manifest.md
@@ -27,6 +27,7 @@ The manifest (`generator/manifest.json`) is the single source of truth for all f
 | `repo` | string | Yes | GitHub repo slug (e.g., `Data-Wise/craft`) |
 | `version` | string | Yes | Current version (CI updates this in formula, not manifest) |
 | `sha256` | string | Yes | SHA256 of release tarball |
+| `revision` | integer | No | Bump when formula/install-script content changes with no version bump — `brew upgrade` compares version+revision only, not file content, so a content-only edit is invisible to it without this |
 | `generated` | boolean | Yes | Whether the generator produces this formula |
 
 ## Plugin-Specific Fields

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 | | Category | Count | Description |
 |---|----------|-------|-------------|
 | :material-console: | [**CLI Tools**](formulas/cli-tools.md) | 9 formulas | Terminal optimizers, workflow tools, exam generators |
-| :material-puzzle: | [**Claude Code Plugins**](formulas/plugins.md) | 6 formulas | Auto-registering plugins via Homebrew |
+| :material-puzzle: | [**Claude Code Plugins**](formulas/plugins.md) | 7 formulas | Auto-registering plugins via Homebrew |
 | :material-cog: | [**Formula Generator**](generator/index.md) | 1 tool | Produces plugin formulas from a single manifest |
 | :material-sync: | [**Automated CI/CD**](ci/index.md) | 2 workflows | Version updates + weekly validation |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ markdown_extensions:
 
 exclude_docs: |
   specs/
+  brainstorm/
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary

Currency check on the live docs site (deployed via \`docs.yml\` on push to \`main\`) found genuine drift, not just cosmetic:

- \`docs/formulas/plugins.md\`'s "Install Pattern" section described the **old symlink-based install** — the generator has used a real-copy tar-pipe install (never a symlink) for several releases, per \`generator/blocks/symlink.sh\`'s own comments and \`tests/test_no_symlink_install.sh\`. Rewrote to match current behavior.
- \`folio\` was **entirely absent** from the per-plugin formula list despite being installable since v1.0.0.
- Stale "6 plugin formulas" / "14 formula entries" counts across \`plugins.md\`, \`generator/index.md\`, \`index.md\` (actual: 7 plugins / 16 total formulas).
- \`generator/manifest.md\`'s Common Fields table never documented the \`revision\` field added in #147.
- \`mkdocs.yml\`'s \`exclude_docs\` excluded \`specs/\` but not \`brainstorm/\`, leaving an orphan-nav build warning.

## Test plan
- [x] \`mkdocs build --strict\` — exit 0, zero warnings (previously 1)
- [x] Verified actual formula counts via \`generator/manifest.json\` directly (7 claude-plugin type, 16 total) rather than assuming

🤖 Generated with [Claude Code](https://claude.com/claude-code)