### PR TITLE
ci(formula-drift): fetch full history so base-ref diffs can run (Task 1)

### DIFF
--- a/.github/workflows/formula-drift.yml
+++ b/.github/workflows/formula-drift.yml
@@ -23,7 +23,12 @@ jobs:
     name: Regen vs committed
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 (full history) — the upcoming revision-drift check needs to
+      # diff Formula/*.rb against the PR base ref / previous push commit, which the
+      # default shallow (depth-1) checkout doesn't have available.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
Task 1 of the release-drift-gates plan (`tasks/todo.md`, `SPEC-release-drift-gates-2026-07-16.md`). Adds `fetch-depth: 0` to `formula-drift.yml`'s checkout step — the default shallow clone has no history, and the upcoming revision-drift check (Task 2) needs to diff `Formula/*.rb` against a base commit that doesn't exist in a depth-1 checkout.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Existing steps unaffected — `check-drift.sh` and `test_no_symlink_install.sh` both still pass locally
- [x] **Real CI acceptance criterion** (per `tasks/todo.md` Task 1): this PR's own CI run is the live proof that the checkout now fetches full history without breaking the existing job — see the Formula Drift Guard check on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)