### PR TITLE
feat(generator): exclude comment/whitespace-only diffs (Task 3)

### DIFF
--- a/generator/check-revision-bump.sh
+++ b/generator/check-revision-bump.sh
@@ -9,9 +9,10 @@
 # never pick up the fix. See generator/manifest.json's `revision` field and
 # docs/generator/manifest.md.
 #
-# This is a minimal first pass (Task 2 of tasks/todo.md): no cosmetic-only
-# diff exclusion yet (Task 3), no revision-exempt label escape hatch yet
-# (Task 4). Any content diff at all, without a version/revision bump, fails.
+# Comment-only and whitespace-only diffs are excluded (Task 3) — a rewrapped
+# bash comment inside the install/post_install heredoc, or a pure Ruby
+# comment change, doesn't affect installed behavior and shouldn't force a
+# revision bump. No revision-exempt label escape hatch yet (Task 4).
 #
 # Usage:  bash generator/check-revision-bump.sh <base-ref> [<head-ref>]
 #         head-ref defaults to HEAD.
@@ -41,6 +42,26 @@ extract_field() {
     | grep -oE '[^ \"]+$' | tr -d '"' || true
 }
 
+# True (exit 0) if every added/removed line in the diff is blank or a comment
+# (leading '#', after stripping the +/- marker and whitespace). Both Ruby's
+# top-level comments and bash comments embedded in the install/post_install
+# heredocs use the same '#' prefix, so one check covers both nesting levels —
+# no need to parse heredoc boundaries separately.
+is_cosmetic_only_diff() {
+  local base="$1" head="$2" formula="$3" line content stripped
+  while IFS= read -r line; do
+    case "$line" in
+      diff\ --git*|index\ *|---\ *|+++\ *|@@*) continue ;;
+    esac
+    content="${line#[+-]}"
+    stripped="$(printf '%s' "$content" | sed -E 's/^[[:space:]]*//')"
+    if [ -n "$stripped" ] && [ "${stripped:0:1}" != "#" ]; then
+      return 1
+    fi
+  done < <(git diff -U0 "$base" "$head" -- "$formula" 2>/dev/null)
+  return 0
+}
+
 fail=0
 changed_formulas=$(git diff --name-only "$BASE_REF" "$HEAD_REF" -- Formula/ 2>/dev/null || true)
 
@@ -58,11 +79,15 @@ for formula in $changed_formulas; do
   head_revision=$(extract_field "$HEAD_REF" "$formula" revision)
 
   if [ "$base_version" = "$head_version" ] && [ "$base_revision" = "$head_revision" ]; then
-    echo "❌ $name: content changed ($BASE_REF → $HEAD_REF) but version/revision did not."
-    echo "   brew upgrade will never detect this change on already-installed machines."
-    echo "   Fix: add/bump \"revision\": N on $name's entry in generator/manifest.json,"
-    echo "   then run: python3 generator/generate.py $name"
-    fail=1
+    if is_cosmetic_only_diff "$BASE_REF" "$HEAD_REF" "$formula"; then
+      echo "✅ $name: comment/whitespace-only change — no revision bump needed."
+    else
+      echo "❌ $name: content changed ($BASE_REF → $HEAD_REF) but version/revision did not."
+      echo "   brew upgrade will never detect this change on already-installed machines."
+      echo "   Fix: add/bump \"revision\": N on $name's entry in generator/manifest.json,"
+      echo "   then run: python3 generator/generate.py $name"
+      fail=1
+    fi
   else
     echo "✅ $name: version or revision changed ($base_version/$base_revision → $head_version/$head_revision)."
   fi


### PR DESCRIPTION
## Summary
Task 3 of the release-drift-gates plan. Extends `check-revision-bump.sh` so a diff of only blank/comment lines doesn't force a revision bump — a rewrapped bash comment inside the install heredoc doesn't affect installed behavior.

## Test plan (3 planted-defect cases, scratch branch discarded after local verification)
- [x] Comment-only change → **PASSES** without a revision bump
- [x] One-line real logic change → **still FAILS** (filter doesn't over-suppress)
- [x] Regression: actual #143 diff (8fb7bc9→5c08475) → **still FAILS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)