### PR TITLE
feat: wire revision-drift gate into CI + planted-defect tests (Tasks 4-6)

### DIFF
--- a/.github/workflows/formula-drift.yml
+++ b/.github/workflows/formula-drift.yml
@@ -39,3 +39,31 @@ jobs:
 
       - name: No-symlink install contract (claude-plugin formulas)
         run: bash tests/test_no_symlink_install.sh
+
+      # Base ref differs by trigger: pull_request compares against the PR's base
+      # commit; push compares against the previous tip (github.event.before). A
+      # push event for a brand-new branch has `before` as the all-zeros sentinel —
+      # skip gracefully rather than error, since there's no real "before" state.
+      - name: Determine revision-drift check inputs
+        id: drift_inputs
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
+            labels=$(jq -r '[(.pull_request.labels // [])[].name] | join(",")' "$GITHUB_EVENT_PATH")
+          else
+            base_sha="${{ github.event.before }}"
+            labels=""
+          fi
+          if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+            echo "labels=$labels" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Revision-drift check (formula content changed without version/revision bump)
+        if: steps.drift_inputs.outputs.skip == 'false'
+        env:
+          PR_LABELS: ${{ steps.drift_inputs.outputs.labels }}
+        run: bash generator/check-revision-bump.sh "${{ steps.drift_inputs.outputs.base_sha }}"

--- a/generator/check-revision-bump.sh
+++ b/generator/check-revision-bump.sh
@@ -12,17 +12,23 @@
 # Comment-only and whitespace-only diffs are excluded (Task 3) — a rewrapped
 # bash comment inside the install/post_install heredoc, or a pure Ruby
 # comment change, doesn't affect installed behavior and shouldn't force a
-# revision bump. No revision-exempt label escape hatch yet (Task 4).
+# revision bump.
 #
-# Usage:  bash generator/check-revision-bump.sh <base-ref> [<head-ref>]
-#         head-ref defaults to HEAD.
-# Exit:   0 = no drift (or version/revision bumped) · 1 = drift detected · 2 = usage error
+# A PR labeled "revision-exempt" bypasses the check entirely (Task 4) — the
+# label is per-PR (never stored in the manifest/codebase, so there's nothing
+# to forget and leave permanently bypassed) and only recognized on
+# pull_request-triggered runs; a push event has no PR/label context and
+# always runs the full check.
+#
+# Usage:  PR_LABELS="label-one,label-two" bash generator/check-revision-bump.sh <base-ref> [<head-ref>]
+#         PR_LABELS is optional (unset/empty on push events); head-ref defaults to HEAD.
+# Exit:   0 = no drift (or version/revision bumped, or exempt) · 1 = drift detected · 2 = usage error
 #
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 if [ $# -lt 1 ]; then
-  echo "Usage: bash generator/check-revision-bump.sh <base-ref> [<head-ref>]" >&2
+  echo "Usage: PR_LABELS=\"...\" bash generator/check-revision-bump.sh <base-ref> [<head-ref>]" >&2
   exit 2
 fi
 
@@ -32,6 +38,11 @@ HEAD_REF="${2:-HEAD}"
 if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
   echo "⚠️  base ref '$BASE_REF' not found — is this checkout shallow? (needs fetch-depth: 0)" >&2
   exit 2
+fi
+
+if printf '%s' "${PR_LABELS:-}" | tr ',' '\n' | grep -qx "revision-exempt"; then
+  echo "⚠️  PR labeled 'revision-exempt' — skipping the revision-bump check entirely."
+  exit 0
 fi
 
 # Extract a field ("version" or "revision") from a Formula/*.rb file at a given ref.

--- a/tests/test_revision_bump_check.sh
+++ b/tests/test_revision_bump_check.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Planted-defect suite for generator/check-revision-bump.sh (Tasks 2-4 of
+# tasks/todo.md, SPEC-release-drift-gates-2026-07-16.md).
+#
+# Cases 1-2 replay the actual folio#18/#143/#147 incident against real repo
+# history (this is also Task 7's dogfood proof — the gate would have caught
+# #143). Cases 3-5 use synthetic scratch commits on a disposable branch,
+# cleaned up on exit regardless of test outcome.
+#
+# Usage:  bash tests/test_revision_bump_check.sh
+# Exit:   0 = all cases passed · 1 = at least one case failed
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+SCRATCH_BRANCH="_test-revision-bump-scratch-$$"
+ORIGINAL_BRANCH="$(git branch --show-current)"
+fail=0
+
+cleanup() {
+  git checkout --quiet "$ORIGINAL_BRANCH" 2>/dev/null || true
+  git branch -D "$SCRATCH_BRANCH" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+check() {
+  local desc="$1" expected_exit="$2"
+  shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" = "$expected_exit" ]; then
+    echo "✅ $desc"
+  else
+    echo "❌ $desc (expected exit $expected_exit, got $actual_exit)"
+    fail=1
+  fi
+}
+
+# --- Case 1 & 2: real incident replay (real repo history; PR #143 / #147) ---
+
+check "Case 1 (dogfood #143): pre-fix diff FAILS for folio" 1 \
+  bash generator/check-revision-bump.sh 8fb7bc9 5c08475
+
+# Case 2 (dogfood #147): the script's overall exit code for this range is
+# NOT asserted as 0 — an unrelated real gap in atlas's formula (a separate,
+# already-known, out-of-scope finding from PR #157) also lives in this range
+# and makes the script correctly exit 1. What this case actually verifies is
+# that folio *specifically* passes (its revision was bumped) — check the
+# captured output rather than the aggregate exit code.
+case2_output=$(bash generator/check-revision-bump.sh 5c08475 dcecd5c 2>/dev/null || true)
+if printf '%s' "$case2_output" | grep -q "✅ folio:"; then
+  echo "✅ Case 2 (dogfood #147): folio specifically passes (revision bumped)"
+else
+  echo "❌ Case 2 (dogfood #147): folio does not show as passing"
+  fail=1
+fi
+
+# --- Case 3: cosmetic-only synthetic change passes without a bump ---
+
+git checkout --quiet -b "$SCRATCH_BRANCH"
+sed -i.bak 's/— a REAL copy, not a/-- a REAL copy, not a/' Formula/folio.rb
+rm -f Formula/folio.rb.bak
+git add Formula/folio.rb
+git commit --quiet -m "test: cosmetic-only comment change"
+COSMETIC_SHA=$(git rev-parse HEAD)
+
+check "Case 3: comment-only change PASSES without a revision bump" 0 \
+  bash generator/check-revision-bump.sh HEAD~1 "$COSMETIC_SHA"
+
+# --- Case 4: real logic change (no bump) still fails ---
+
+git checkout --quiet "$SCRATCH_BRANCH"
+sed -i.bak 's/mkdir -p "\$MARKETPLACE_DIR" 2>\/dev\/null || true/mkdir -p "$MARKETPLACE_DIR_TEST" 2>\/dev\/null || true/' Formula/folio.rb
+rm -f Formula/folio.rb.bak
+git add Formula/folio.rb
+git commit --quiet -m "test: real logic change, no revision bump"
+LOGIC_SHA=$(git rev-parse HEAD)
+
+check "Case 4: real logic change (no bump) still FAILS" 1 \
+  bash generator/check-revision-bump.sh "$COSMETIC_SHA" "$LOGIC_SHA"
+
+# --- Case 5: revision-exempt label bypasses even a real, unbumped change ---
+
+check "Case 5: PR_LABELS=revision-exempt bypasses the check entirely" 0 \
+  env PR_LABELS="revision-exempt" bash generator/check-revision-bump.sh "$COSMETIC_SHA" "$LOGIC_SHA"
+
+check "Case 5b: an unrelated label does NOT bypass" 1 \
+  env PR_LABELS="some-other-label" bash generator/check-revision-bump.sh "$COSMETIC_SHA" "$LOGIC_SHA"
+
+exit "$fail"


### PR DESCRIPTION
## Summary
- Task 4: `revision-exempt` PR-label bypass for `check-revision-bump.sh`
- Task 5: wire the check into `formula-drift.yml` (handles `pull_request` and `push` triggers; skips gracefully on a brand-new branch)
- Task 6: `tests/test_revision_bump_check.sh` — 6 cases, including a dogfood replay of the real #143/#147 incident against actual repo history

Continues `feature/release-drift-gates` (Tasks 1-3, merged in #155/#157/#158) per `tasks/todo.md`.

## Test plan
- [x] `bash tests/test_revision_bump_check.sh` → 6/6 pass locally
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI run on this PR exercises the new `pull_request`-trigger path for real (the actual end-to-end proof of Task 5's base-ref/label derivation)

## Note
Case 2's dogfood check verifies folio's line specifically rather than the aggregate script exit code — an unrelated, already-known gap in the `atlas` formula (found as a side effect of Task 2's dogfood testing, PR #157) also lives in that commit range and correctly makes the aggregate exit 1.