### PR TITLE
feat: .STATUS conflict-marker guard + CI wiring + docs (Tasks 8-10)

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -151,3 +151,7 @@ progress: All phases merged to main, repo cleaned up, CI verified
 → Verify update-formula workflow uses App token correctly (next time a project releases)
 → Monitor: push-trigger suppression may need further investigation (PR #94 fix didn't fully resolve)
 → After next craft release lands, confirm regenerated casks emit `depends_on macos: :catalina` (proves the generator root-cause fix holds in practice)
+<<<<<<< HEAD
+planted defect for CI trigger verification (Task 9) — will be reverted
+=======
+>>>>>>> test

--- a/.STATUS
+++ b/.STATUS
@@ -151,7 +151,3 @@ progress: All phases merged to main, repo cleaned up, CI verified
 → Verify update-formula workflow uses App token correctly (next time a project releases)
 → Monitor: push-trigger suppression may need further investigation (PR #94 fix didn't fully resolve)
 → After next craft release lands, confirm regenerated casks emit `depends_on macos: :catalina` (proves the generator root-cause fix holds in practice)
-<<<<<<< HEAD
-planted defect for CI trigger verification (Task 9) — will be reverted
-=======
->>>>>>> test

--- a/.github/workflows/status-guard.yml
+++ b/.github/workflows/status-guard.yml
@@ -1,0 +1,25 @@
+# .STATUS Conflict-Marker Guard
+#
+# .STATUS is hand-edited frequently, often across concurrent worktrees/PRs.
+# This fails CI if a literal git merge-conflict marker (<<<<<<<, =======,
+# >>>>>>>) was committed by mistake.
+
+name: Status Guard
+
+on:
+  push:
+    paths:
+      - '.STATUS'
+  pull_request:
+    paths:
+      - '.STATUS'
+
+jobs:
+  conflict-markers:
+    name: Check .STATUS for conflict markers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check .STATUS for conflict markers
+        run: bash generator/check-status-conflict-markers.sh .STATUS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ mkdocs build --strict     # Build and validate
 
 **`features.marketplace` and `features.claude_detection` are required for every `claude-plugin` entry**, not optional extras — omitting either silently drops the corresponding install-script block with no error at generate- or install-time (folio#18: a new entry shipped with no `features` key at all, so `brew install` reported success but never registered the plugin with Claude Code). `tests/test_manifest_required_features.sh` gates this in CI.
 
+**A `revision` bump is required whenever a `Formula/*.rb`'s content changes with no `version` change** — `brew upgrade` compares only `version`+`revision` against the installed receipt, not file content, so a content-only fix (e.g. an install-script tweak) is otherwise invisible to already-installed machines. `formula-drift.yml`'s revision-drift check (`generator/check-revision-bump.sh`) fails CI on this class of change; fix by adding/bumping `"revision": N` on the affected entry in `generator/manifest.json` and regenerating. A PR can bypass the check entirely by adding the `revision-exempt` label (e.g. for changes that are genuinely cosmetic but not caught by the check's own comment/whitespace-diff exclusion) — the label is per-PR, not persisted anywhere, so there's no manifest flag to remember or forget; the PR's own label history is the audit trail.
+
 ```bash
 python3 generator/generate.py              # Generate all 7 plugin formulas
 python3 generator/generate.py craft        # Generate one formula

--- a/generator/check-status-conflict-markers.sh
+++ b/generator/check-status-conflict-markers.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# .STATUS conflict-marker guard.
+#
+# Fails if the target file contains an unresolved git merge-conflict marker
+# (a leftover from a botched rebase/merge that was committed by mistake).
+# `.STATUS` is hand-edited frequently across concurrent worktrees/sessions in
+# this repo, making it a plausible place for a stray marker to slip through.
+#
+# Usage:  bash generator/check-status-conflict-markers.sh [<file>]
+#         <file> defaults to .STATUS at the repo root.
+# Exit:   0 = clean · 1 = conflict marker(s) found · 2 = usage/file-not-found error
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+TARGET="${1:-.STATUS}"
+
+if [ ! -f "$TARGET" ]; then
+  echo "⚠️  file not found: $TARGET" >&2
+  exit 2
+fi
+
+matches=$(grep -n '^<<<<<<<\|^=======\|^>>>>>>>' "$TARGET" || true)
+
+if [ -n "$matches" ]; then
+  echo "❌ conflict marker(s) found in $TARGET:"
+  echo "$matches"
+  exit 1
+fi
+
+echo "✅ $TARGET: no conflict markers."
+exit 0

--- a/tests/test_status_conflict_markers.sh
+++ b/tests/test_status_conflict_markers.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Planted-defect test for generator/check-status-conflict-markers.sh (Task 8
+# of tasks/todo.md, SPEC-release-drift-gates-2026-07-16.md).
+#
+# Usage:  bash tests/test_status_conflict_markers.sh
+# Exit:   0 = all cases passed · 1 = at least one case failed
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+SCRATCH_DIR="$(mktemp -d)"
+fail=0
+
+cleanup() {
+  rm -rf "$SCRATCH_DIR"
+}
+trap cleanup EXIT
+
+check() {
+  local desc="$1" expected_exit="$2"
+  shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" = "$expected_exit" ]; then
+    echo "✅ $desc"
+  else
+    echo "❌ $desc (expected exit $expected_exit, got $actual_exit)"
+    fail=1
+  fi
+}
+
+# --- Case 1: unmodified real .STATUS passes ---
+
+check "Case 1: real .STATUS is clean" 0 \
+  bash generator/check-status-conflict-markers.sh .STATUS
+
+# --- Case 2: planted conflict marker fails ---
+
+CONFLICT_FILE="$SCRATCH_DIR/STATUS-with-conflict"
+cp .STATUS "$CONFLICT_FILE"
+cat >>"$CONFLICT_FILE" <<'EOF'
+<<<<<<< HEAD
+some local change
+=======
+some incoming change
+>>>>>>> feature/other-branch
+EOF
+
+check "Case 2: planted conflict marker FAILS" 1 \
+  bash generator/check-status-conflict-markers.sh "$CONFLICT_FILE"
+
+# --- Case 3: missing file is a usage error, not a silent pass ---
+
+check "Case 3: missing file exits 2 (usage error)" 2 \
+  bash generator/check-status-conflict-markers.sh "$SCRATCH_DIR/does-not-exist"
+
+exit "$fail"


### PR DESCRIPTION
## Summary
- Task 8: `generator/check-status-conflict-markers.sh` — fails on a literal conflict marker in `.STATUS`
- Task 9: new `status-guard.yml` workflow, triggered on any push/PR touching `.STATUS`
- Task 10: `CLAUDE.md` paragraph documenting the revision-drift gate + `revision-exempt` label, adjacent to the existing `features`-flag paragraph

Completes `tasks/todo.md`'s remaining tasks (1-7 shipped in #155/#157/#158/#159).

## Test plan
- [x] `bash tests/test_status_conflict_markers.sh` → 3/3 pass locally (clean real `.STATUS`, planted-defect scratch copy, missing-file usage error)
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] **E2E**: pushed a throwaway commit planting a real conflict marker in `.STATUS` — `status-guard.yml` fired and the "Check .STATUS for conflict markers" check went red as expected, proving both the path-filter trigger and the detection logic work in a live PR run. Reverted in the next commit before merge.