### PR TITLE
craft: update to v4.2.0

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -195,3 +195,14 @@ progress: SPEC-release-drift-gates-2026-07-16.md fully implemented and merged to
 → Verify update-formula workflow uses App token correctly (next time a project releases)
 → Monitor: push-trigger suppression may need further investigation (PR #94 fix didn't fully resolve)
 → After next craft release lands, confirm regenerated casks emit `depends_on macos: :catalina` (proves the generator root-cause fix holds in practice)
+→ craft's `homebrew-release.yml` still does a direct `git push origin main` — now
+  rejected by this repo's branch protection (added since the workflow was last
+  updated). It needs to switch to a PR-based push. Manually recovered v4.2.0's
+  formula update via PR #164 as a one-off (2026-07-19); fix the workflow before
+  the next craft release to avoid repeating this.
+→ `check-revision-bump.sh`'s `extract_field` looks for an explicit `version "..."`
+  line in the formula — craft.rb (and any URL-versioned formula) has none,
+  Homebrew infers version from the `url` tag. This produces a false-positive
+  "content changed without version bump" on every version-only craft update.
+  Used the `revision-exempt` label to unblock PR #164; the script needs to also
+  diff the `url` line's version segment, not just a literal `version` field.

--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -5,8 +5,8 @@
 class Craft < Formula
   desc "Full-stack developer toolkit for Claude Code with 48 commands"
   homepage "https://github.com/Data-Wise/craft"
-  url "https://github.com/Data-Wise/craft/archive/refs/tags/v4.1.0.tar.gz"
-  sha256 "071d4f9eab555994172efdd5cca2312d89ccf65caf3bba109903baceedb5018f"
+  url "https://github.com/Data-Wise/craft/archive/refs/tags/v4.2.0.tar.gz"
+  sha256 "794e6d3e78fb15298723bd0f4f995da5bf1c81e15528fd4bc0522204922892eb"
   license "MIT"
 
   depends_on "jq"

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -10,8 +10,8 @@
       "homepage": "https://github.com/Data-Wise/craft",
       "source": "github",
       "repo": "Data-Wise/craft",
-      "version": "4.1.0",
-      "sha256": "071d4f9eab555994172efdd5cca2312d89ccf65caf3bba109903baceedb5018f",
+      "version": "4.2.0",
+      "sha256": "794e6d3e78fb15298723bd0f4f995da5bf1c81e15528fd4bc0522204922892eb",
       "command_count": 48,
       "dependencies": {
         "runtime": [


### PR DESCRIPTION
Mechanical formula update — the automated `homebrew-release.yml` workflow in Data-Wise/craft ran on the v4.2.0 GitHub release but failed to push directly to `main` now that this repo requires PR + status checks. This PR carries the same manifest.json + regenerated craft.rb the workflow would have produced (sha256 verified against the v4.2.0 tarball).

Follow-up filed separately: the workflow itself needs to switch from direct push to opening a PR.