### PR TITLE
fix(check-revision-bump): recognize URL-tag versions

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -195,14 +195,17 @@ progress: SPEC-release-drift-gates-2026-07-16.md fully implemented and merged to
 → Verify update-formula workflow uses App token correctly (next time a project releases)
 → Monitor: push-trigger suppression may need further investigation (PR #94 fix didn't fully resolve)
 → After next craft release lands, confirm regenerated casks emit `depends_on macos: :catalina` (proves the generator root-cause fix holds in practice)
-→ craft's `homebrew-release.yml` still does a direct `git push origin main` — now
-  rejected by this repo's branch protection (added since the workflow was last
-  updated). It needs to switch to a PR-based push. Manually recovered v4.2.0's
-  formula update via PR #164 as a one-off (2026-07-19); fix the workflow before
-  the next craft release to avoid repeating this.
-→ `check-revision-bump.sh`'s `extract_field` looks for an explicit `version "..."`
-  line in the formula — craft.rb (and any URL-versioned formula) has none,
-  Homebrew infers version from the `url` tag. This produces a false-positive
-  "content changed without version bump" on every version-only craft update.
-  Used the `revision-exempt` label to unblock PR #164; the script needs to also
-  diff the `url` line's version segment, not just a literal `version` field.
+→ RESOLVED (2026-07-19): craft's `homebrew-release.yml` "Commit and push to tap"
+  step switched from a direct `git push origin main` to pushing a
+  `craft-release/vX.Y.Z` branch and opening + auto-merging a PR (via the same
+  GitHub App token) against this repo's protected `main`. Fixed in the craft
+  repo, not here — see craft's own `.github/workflows/homebrew-release.yml`.
+→ RESOLVED (2026-07-19): `check-revision-bump.sh`'s `extract_field` only
+  matched an explicit `version "..."` line, which craft.rb (and any
+  URL-tag-versioned formula) doesn't have — Homebrew infers the version from
+  the `url`'s git tag. Added `extract_version()`, which falls back to parsing
+  the tag out of the `url` line when no explicit field is present, so a real
+  version bump is recognized without needing the `revision-exempt` label.
+  Covered by new Case 6 in `tests/test_revision_bump_check.sh` (verified to
+  fail without the fix, pass with it). Branch:
+  `feature/fix-revision-check-url-tag-version`.

--- a/generator/check-revision-bump.sh
+++ b/generator/check-revision-bump.sh
@@ -53,6 +53,26 @@ extract_field() {
     | grep -oE '[^ \"]+$' | tr -d '"' || true
 }
 
+# Version for a Formula/*.rb at a given ref. Most formulas here have no
+# explicit `version` line — Homebrew infers it from the `url`'s git tag
+# (e.g. `url ".../archive/refs/tags/v4.2.0.tar.gz"`) — so fall back to
+# extracting the tag when the literal field is absent. Without this,
+# base_version/head_version are both "" for every URL-tag-versioned formula,
+# and a real version bump reads as "content changed, version did not".
+extract_version() {
+  local ref="$1" formula="$2"
+  local explicit
+  explicit=$(extract_field "$ref" "$formula" version)
+  if [ -n "$explicit" ]; then
+    printf '%s' "$explicit"
+    return
+  fi
+  git show "$ref:$formula" 2>/dev/null \
+    | grep -oE '^\s*url\s+"[^"]+"' \
+    | grep -oE '/tags/v?[^/"]+\.(tar\.gz|zip|tar\.bz2)"' \
+    | sed -E 's#^/tags/v?##; s#\.(tar\.gz|zip|tar\.bz2)"$##' || true
+}
+
 # True (exit 0) if every added/removed line in the diff is blank or a comment
 # (leading '#', after stripping the +/- marker and whitespace). Both Ruby's
 # top-level comments and bash comments embedded in the install/post_install
@@ -84,8 +104,8 @@ fi
 for formula in $changed_formulas; do
   name=$(basename "$formula" .rb)
 
-  base_version=$(extract_field "$BASE_REF" "$formula" version)
-  head_version=$(extract_field "$HEAD_REF" "$formula" version)
+  base_version=$(extract_version "$BASE_REF" "$formula")
+  head_version=$(extract_version "$HEAD_REF" "$formula")
   base_revision=$(extract_field "$BASE_REF" "$formula" revision)
   head_revision=$(extract_field "$HEAD_REF" "$formula" revision)
 

--- a/tests/test_revision_bump_check.sh
+++ b/tests/test_revision_bump_check.sh
@@ -88,4 +88,26 @@ check "Case 5: PR_LABELS=revision-exempt bypasses the check entirely" 0 \
 check "Case 5b: an unrelated label does NOT bypass" 1 \
   env PR_LABELS="some-other-label" bash generator/check-revision-bump.sh "$COSMETIC_SHA" "$LOGIC_SHA"
 
+# --- Case 6: URL-tag-versioned formula (no explicit `version` field) ---
+#
+# craft.rb has no `version "..."` line — Homebrew infers the version from the
+# `url`'s git tag. Before the extract_version() fallback, base/head version
+# both read as "" for every bump, so a real logic change alongside a version
+# bump false-positived as "content changed but version did not" (the
+# incident that forced the "revision-exempt" label workaround on v4.2.0).
+
+git checkout --quiet "$SCRATCH_BRANCH"
+CRAFT_BASE_SHA=$(git rev-parse HEAD)
+sed -i.bak \
+  -e 's/refs\/tags\/v4\.2\.0\.tar\.gz/refs\/tags\/v4.3.0.tar.gz/' \
+  -e 's/desc "Full-stack developer toolkit for Claude Code with 48 commands"/desc "Full-stack developer toolkit for Claude Code with 49 commands"/' \
+  Formula/craft.rb
+rm -f Formula/craft.rb.bak
+git add Formula/craft.rb
+git commit --quiet -m "test: url-tag version bump + real content change"
+CRAFT_BUMP_SHA=$(git rev-parse HEAD)
+
+check "Case 6: url-tag version bump is recognized (no false positive)" 0 \
+  bash generator/check-revision-bump.sh "$CRAFT_BASE_SHA" "$CRAFT_BUMP_SHA"
+
 exit "$fail"


### PR DESCRIPTION
## Summary
- `extract_field` in `generator/check-revision-bump.sh` only matched an explicit `version "..."` line in a formula file. URL-tag-versioned formulas (e.g. `Formula/craft.rb`, which has no `version` field — Homebrew infers it from the `url`'s git tag) always read `base_version == head_version == ""`, so every real content-changing version bump false-positived as "content changed but version/revision did not". This forced the `revision-exempt` label workaround on PR #164 (craft v4.2.0).
- Adds `extract_version()`: tries the explicit `version` field first, falls back to parsing the version out of the `url "...tags/vX.Y.Z.tar.gz"` line when absent.
- Adds Case 6 to `tests/test_revision_bump_check.sh` using `Formula/craft.rb` (real URL-tag-versioned formula) with a synthetic version bump + content change — verified to FAIL against the pre-fix script and PASS against the fix.

## Context
Both issues (this one, plus craft's `homebrew-release.yml` direct-push rejection) were logged in this repo's `.STATUS` "🎯 Next Action" section during the v4.2.0 release recovery (PR #164). This PR closes the `extract_field` gap; the workflow-side fix lives in the craft repo (`homebrew-release.yml`, separately).

## Test plan
- [x] `bash tests/test_revision_bump_check.sh` — all 7 cases pass (Cases 1-5b unchanged, new Case 6 added)
- [x] Verified Case 6 fails without the fix (positive control) via `git stash push -- generator/check-revision-bump.sh`
- [x] Re-ran the fixed script against the real v4.1.0→v4.2.0 `craft.rb` history: correctly reports "version or revision changed" with no `revision-exempt` label needed
- [ ] CI: "Regen vs committed" / "Check .STATUS for conflict markers" required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)