### PR TITLE
atlas: update to v0.14.0

### DIFF
--- a/Formula/atlas.rb
+++ b/Formula/atlas.rb
@@ -5,8 +5,8 @@
 class Atlas < Formula
   desc "Project state engine with registry, sessions, and capture"
   homepage "https://github.com/Data-Wise/atlas"
-  url "https://github.com/Data-Wise/atlas/archive/refs/tags/v0.13.1.tar.gz"
-  sha256 "85dbea3f8d71dbdca208131dbf5993d68ef2447bacb2337d9bca6185d66f91e2"
+  url "https://github.com/Data-Wise/atlas/archive/refs/tags/v0.14.0.tar.gz"
+  sha256 "e62bcf2e6f9902ed47d416310f943ebcb5cb53475bc9c530d0e2379e69f0dd04"
   license "MIT"
 
   depends_on "python@3.12" => :build

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -396,8 +396,8 @@
       "homepage": "https://github.com/Data-Wise/atlas",
       "source": "github",
       "repo": "Data-Wise/atlas",
-      "version": "0.13.1",
-      "sha256": "85dbea3f8d71dbdca208131dbf5993d68ef2447bacb2337d9bca6185d66f91e2",
+      "version": "0.14.0",
+      "sha256": "e62bcf2e6f9902ed47d416310f943ebcb5cb53475bc9c530d0e2379e69f0dd04",
       "generated": false
     },
     "examark": {


### PR DESCRIPTION
Formula + manifest bump to v0.14.0 (sha256 verified against the tagged tarball).

Manual PR because homebrew-release.yml's direct push to main was rejected by the new branch protection (GH006) — the workflow needs updating to open a PR instead; flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)