### PR TITLE
docs(specs): brainstorm + spec + grill for self-skipping required checks

### DIFF
--- a/BRAINSTORM-required-checks-path-filtering-2026-07-19.md
+++ b/BRAINSTORM-required-checks-path-filtering-2026-07-19.md
@@ -1,0 +1,126 @@
+# BRAINSTORM: Required-checks path-filtering vs. unconditional/self-skipping
+
+**Date:** 2026-07-19
+**Depth:** quick | **Focus:** ops
+**Context:** Follow-up to PRs #162/#163/#165/#166 (main branch-protection setup + fix + live verification)
+
+## What the question actually means
+
+GitHub's `required_status_checks.contexts` is a flat list of check-run
+*names*. It has **no path-awareness of its own** — GitHub just waits for a
+check run with that exact name to report on the PR's head commit. If the
+name never shows up (because the underlying workflow's own `on: pull_request:
+paths:` filter didn't match), GitHub doesn't skip it — it sits in the PR's
+"Some checks haven't completed yet" state **forever**, and `mergeStateStatus`
+reports `BLOCKED`.
+
+That's exactly what happened today: `Regen vs committed` (triggers only on
+`generator/**`/`Formula/**`) and `Check .STATUS for conflict markers`
+(triggers only on `.STATUS`) are both **required**, but any single PR only
+ever touches one of those path sets (or neither). Two live data points from
+today:
+
+- PR #162/#163/#166 (`.STATUS`-only) → `Check .STATUS...` ran and passed,
+  `Regen vs committed` never started → `BLOCKED` → merged with `--admin`.
+- PR #165 (`generator/**`) → `Regen vs committed` ran and passed,
+  `Check .STATUS...` never started → but this one went `CLEAN`.
+
+Wait — why did #165 go `CLEAN` but #162 went `BLOCKED`, if both are missing
+one of two required checks? Because #165 *also* touched `.STATUS` (every one
+of today's PRs did, since they were all `.STATUS`-recording PRs) — so it
+happened to satisfy both contexts. A PR that touches `generator/**` *only*
+(no `.STATUS` edit) would reproduce the same `BLOCKED` state #162 hit, just
+from the other direction. **The gate is currently only reliably satisfiable
+by PRs that happen to touch both path sets at once** — which is a narrow and
+accidental intersection, not a real property of the workflow design.
+
+So the actual production behavior right now:
+
+| PR touches | `Regen vs committed` | `Check .STATUS...` | Result |
+|---|---|---|---|
+| `Formula/**` only | ran | never started | BLOCKED |
+| `.STATUS` only | never started | ran | BLOCKED |
+| both | ran | ran | CLEAN (today's lucky case) |
+| neither (e.g. docs, workflow YAML, README) | never started | never started | BLOCKED |
+
+Every single-purpose PR gets blocked. Today's PRs merged "clean" by
+coincidence of always bundling a `.STATUS` note with the code change — not
+because the gate is actually working as designed.
+
+## The two paths forward
+
+### Option A — Path-filtered, accept `--admin` (current state)
+
+Keep both workflows path-filtered as-is; keep both required. Any PR that
+doesn't hit the lucky intersection needs `--admin` to merge on green.
+
+- **Quick win, zero extra work** — already the current state, nothing to do.
+- **Cost:** `--admin` bypasses **all** branch protection for that merge, not
+  just the missing-check problem — including `enforce_admins`-adjacent
+  guarantees. It's a blunt instrument used routinely, which is the opposite
+  of what required-checks were added for (SPEC's whole point was "CI red
+  should block merges" — an admin override on every other PR erodes that).
+- Every future contributor (not just this session) hits the same BLOCKED
+  wall and needs to know `--admin` is the sanctioned workaround — that's
+  tribal knowledge, not a control.
+
+### Option B — Unconditional triggers, job-level skip (self-skipping)
+
+Remove the `paths:` filter from `on: pull_request:` in both
+`formula-drift.yml` and `status-guard.yml` (and drop `Validate all formulas`
+from required — already done, correctly, since it's structurally
+unfixable via this pattern — it has no PR trigger to begin with, only
+`schedule`/`workflow_dispatch`). Add a path-check *inside* the job (e.g.
+`dorny/paths-filter` or a plain `git diff --name-only` grep) that exits 0
+immediately when the relevant paths weren't touched.
+
+- **Every PR gets a real, fast-completing check result** — no more BLOCKED
+  wall, no more `--admin`, ever, for these two checks.
+- **Cost:** touches 3 files (`formula-drift.yml`, `status-guard.yml`, plus
+  the `.STATUS` doc-only record of the change) instead of one API call.
+  Needs its own E2E verification per `e2e-before-pr.md` (a PR that touches
+  neither path — genuine skip case — plus one that does, for both
+  workflows) before it can be trusted.
+- Slightly more moving parts to maintain (a skip-condition in the job,
+  rather than relying on the trigger's own `paths:` block) — but this is a
+  small, well-known GitHub Actions pattern, not novel risk.
+
+## Recommended Next Step
+
+**→ Option B (self-skipping), because the `--admin` habit is the actual
+risk, not the extra workflow-file edits.** Today's session already needed
+`--admin` three times in a row (#162, #163, #166) — that's not a one-off
+inconvenience, it's the *default* outcome for any PR that doesn't happen to
+touch both path sets, and `.STATUS`-only PRs (routine, frequent in this
+repo per its own `.STATUS` history) will hit it every time. An admin
+override that's routine stops functioning as a safety rail — the SPEC this
+whole thread traces back to (`SPEC-release-drift-gates-2026-07-16.md`)
+existed specifically to make CI red block merges; a required-but-usually-
+bypassed check reproduces the exact gap that SPEC closed, just one layer
+down.
+
+Option A is the cheaper immediate choice but only defers the cost — it will
+resurface on the next `.STATUS`-only or `generator`-only PR that isn't
+bundled with the other path.
+
+## Quick Wins (< 30 min)
+
+1. **Add `dorny/paths-filter`-based skip to `status-guard.yml`** — smaller
+   of the two workflows, good first proof of the pattern before touching
+   `formula-drift.yml`.
+
+## Medium Effort (1-2 hrs)
+
+- [ ] Apply the same unconditional-trigger + job-skip pattern to
+      `formula-drift.yml`.
+- [ ] E2E-verify both directions per workflow (path touched → real check;
+      path not touched → check still reports, fast, green) before opening
+      the PR — required by `e2e-before-pr.md` since this changes CI
+      behavior, not just docs.
+- [ ] Record the fix in `.STATUS`, same pattern as PRs #162/#163/#166.
+
+## Long-term (future sessions)
+
+- [ ] Reconsider `Validate all formulas` (currently non-required, `schedule`-
+      only) — could gain a lightweight `pull_request` trigger scoped to
+      `Formula/**` too, if formula-audit-on-PR is ever wanted as a gate.

--- a/docs/specs/GRILL-required-checks-self-skip-2026-07-19.md
+++ b/docs/specs/GRILL-required-checks-self-skip-2026-07-19.md
@@ -1,0 +1,93 @@
+# GRILL: Self-Skipping Required Checks
+
+**Date:** 2026-07-19 · **Target:** [SPEC-required-checks-self-skip-2026-07-19.md](SPEC-required-checks-self-skip-2026-07-19.md)
+**Brainstorm:** [BRAINSTORM-required-checks-path-filtering-2026-07-19.md](../../BRAINSTORM-required-checks-path-filtering-2026-07-19.md)
+
+## Decision Ledger
+
+### 1. Diff-base resolution for the skip check (weakest recommendation)
+
+**Decision:** Extend `formula-drift.yml`'s existing "Determine revision-drift check inputs" step
+rather than writing a separate minimal one.
+
+**Reasoning:** That step already hardened PR-vs-push event branching (reads
+`$GITHUB_EVENT_PATH` via `jq`, all-zeros sentinel for new branches) for the revision-bump check.
+Reusing it gives the skip-check and the revision-bump check one shared source of truth for "what
+changed" — avoids a second, potentially-divergent copy of event-type branching logic in the same
+file.
+
+**Consequence accepted:** Touches an already-delicate step; needs careful review so the skip-path
+addition doesn't regress the revision-bump logic it currently serves alone. `status-guard.yml` has
+no equivalent existing step (it's a much simpler workflow), so this specific risk doesn't apply
+there — see Decision 3.
+
+### 2. Silent-skip safety (riskiest assumption)
+
+**Decision:** Fail closed on ambiguity. If the diff-base/path resolution itself errors (can't
+determine base ref, event payload malformed, etc.), the job **fails**, never silently skips.
+"I don't know what changed" must never be treated as "nothing changed."
+
+**Reasoning:** A required check that's always green because its own skip-detection is silently
+broken is worse than today's loud `BLOCKED` wall — it looks like coverage while providing none.
+
+**Consequence accepted / promoted to Acceptance Criteria:** The SPEC's existing planted-defect
+Acceptance Criteria (a real `Formula/**` drift bug still fails `Regen vs committed`; a real
+`.STATUS` conflict marker still fails its check) now double as the CI-enforced regression test for
+this fail-closed invariant — not just a manual PR-time spot check.
+
+### 3. Rollout order (implementation regret)
+
+**Decision:** Ship `status-guard.yml`'s self-skip fix first, in its own PR, before touching
+`formula-drift.yml`.
+
+**Reasoning:** `status-guard.yml` is small and has no pre-existing delicate multi-branch logic —
+it's the cheap place to validate the self-skip pattern (both directions: path touched → real
+check runs; path not touched → fast green skip) end-to-end. If the pattern itself has a flaw,
+it surfaces here first, before it's combined with the already-fragile
+"Determine revision-drift check inputs" step in `formula-drift.yml` (Decision 1).
+
+**Consequence accepted:** Two PRs instead of one; a brief window where only one of the two
+required checks is fixed (the other still hits the `BLOCKED`-on-`.STATUS`-only-PR /
+`BLOCKED`-on-`Formula`-only-PR wall from the opposite direction than before, until the second PR
+lands).
+
+### 4. CI-minutes blast radius
+
+**Decision:** Proceed as scoped; explicitly note to glance at CI-minutes usage a few weeks after
+rollout, not gate the change on it now.
+
+**Reasoning:** `formula-drift.yml` moving from paths-filtered to unconditional `pull_request`
+means it now runs (briefly) on every PR, including automation-generated ones (e.g. craft's
+`homebrew-release.yml` auto-merge PRs). A `git diff --name-only` + exit is sub-second; this repo's
+PR volume and CI-minutes budget don't currently make this a real cost.
+
+**Consequence accepted:** No monitoring mechanism added — this is a manual "keep an eye on it"
+note, not a metric or alert. Acceptable given the repo's small scale; revisit only if PR volume or
+CI cost materially changes.
+
+### 5. Scope boundary — `Validate all formulas`
+
+**Decision:** Confirmed out of scope. `Validate all formulas` stays without a `pull_request`
+trigger; giving it one (to make it a real per-PR formula-audit gate) is a separate, later design
+decision, not folded into this SPEC.
+
+**Reasoning:** It's a heavier macOS job historically shaped as a weekly cron check, not a PR gate
+— whether every PR should run a full formula-audit is a different question than "make the two
+already-required checks self-skip correctly." Bundling it would grow this SPEC's diff and defer
+shipping the two already-designed fixes.
+
+**Consequence accepted:** The brainstorm's Long-term item (`Validate all formulas` PR-scoped
+trigger) remains open and unscheduled — no regression, just explicitly not addressed here.
+
+## Open Questions
+
+None remaining — all 5 branches from the SPEC's "Open Questions" section and grill's attack
+angles resolved above. `Validate all formulas` PR-trigger question is explicitly deferred (Decision
+5), not unresolved.
+
+## Handoff
+
+SPEC status should move from "Draft — grill before driving" to "Approved — ready to drive."
+Suggested next step: `/craft:plan docs/specs/SPEC-required-checks-self-skip-2026-07-19.md` (or
+implement directly per the rollout order in Decision 3 — `status-guard.yml` first, own PR,
+E2E-verified per its Acceptance Criteria, before touching `formula-drift.yml`).

--- a/docs/specs/SPEC-required-checks-self-skip-2026-07-19.md
+++ b/docs/specs/SPEC-required-checks-self-skip-2026-07-19.md
@@ -1,0 +1,96 @@
+# SPEC: Self-Skipping Required Checks (fix the path-filtered BLOCKED wall)
+
+**Date:** 2026-07-19 · **Status:** Approved — ready to drive
+**Grill:** [GRILL-required-checks-self-skip-2026-07-19.md](GRILL-required-checks-self-skip-2026-07-19.md)
+**Brainstorm:** [BRAINSTORM-required-checks-path-filtering-2026-07-19.md](../../BRAINSTORM-required-checks-path-filtering-2026-07-19.md)
+**Repo:** `homebrew-tap`
+**Related:** [#162](https://github.com/Data-Wise/homebrew-tap/pull/162), [#163](https://github.com/Data-Wise/homebrew-tap/pull/163), [#165](https://github.com/Data-Wise/homebrew-tap/pull/165), [#166](https://github.com/Data-Wise/homebrew-tap/pull/166), [SPEC-release-drift-gates-2026-07-16.md](SPEC-release-drift-gates-2026-07-16.md)
+
+## Problem
+
+`main` branch protection (added 2026-07-19, closing SPEC-release-drift-gates-2026-07-16.md's
+deferred open question) requires two check-run contexts: `Regen vs committed`
+(`formula-drift.yml`) and `Check .STATUS for conflict markers` (`status-guard.yml`). Both
+workflows are triggered by `on: pull_request: paths:` filters scoped to their own concern
+(`generator/**`/`Formula/**` and `.STATUS` respectively).
+
+GitHub's required-status-checks has no path-awareness: if a required context never reports
+because its workflow's trigger didn't match, GitHub doesn't skip it — it waits forever and
+`mergeStateStatus` reports `BLOCKED`. In practice this means:
+
+| PR touches | `Regen vs committed` | `Check .STATUS...` | Result |
+|---|---|---|---|
+| `Formula/**`/`generator/**` only | ran | never started | BLOCKED |
+| `.STATUS` only | never started | ran | BLOCKED |
+| both | ran | ran | CLEAN |
+| neither (docs, workflow YAML, README, etc.) | never started | never started | BLOCKED |
+
+Three of today's four PRs (#162, #163, #166 — all `.STATUS`-only) hit `BLOCKED` and were merged
+via `gh pr merge --admin`, bypassing branch protection entirely for that merge (not just the
+missing-check gap). Only #165 went `CLEAN`, and only because it happened to touch both path sets
+at once (`generator/**` fix bundled with a `.STATUS` note) — not because the gate worked as
+designed. A `generator/**`-only PR would reproduce the same `BLOCKED` wall from the other side.
+
+An admin override that's the routine outcome (not the exception) stops functioning as a safety
+rail — it reproduces, one layer down, the exact gap SPEC-release-drift-gates-2026-07-16.md was
+written to close (CI red should block merges; here, CI never-ran also fails to block merges,
+just via a different mechanism than the original problem).
+
+## Scope
+
+### In scope
+
+- Remove the `paths:` filter from `formula-drift.yml`'s and `status-guard.yml`'s `pull_request`
+  triggers (keep `push` triggers as-is — they're not part of the required-checks problem).
+- Add a job-level path check inside each workflow (plain `git diff --name-only` against the
+  merge-base, matching this repo's existing hand-rolled-bash convention — no new third-party
+  action dependency) that exits 0 immediately, without running the real check logic, when the
+  relevant paths weren't touched by the PR.
+- Both job names (`Regen vs committed`, `Check .STATUS for conflict markers`) stay unchanged —
+  no branch-protection API changes needed once this ships; the fix is entirely on the workflow
+  side.
+- E2E verification (per `e2e-before-pr.md`): for each workflow, one real PR/commit that touches
+  the relevant path (real check runs) and one that doesn't (check reports fast + green via the
+  skip path) — not just YAML lint.
+- `.STATUS` record of the change, same pattern as PRs #162/#163/#166.
+
+### Explicitly out of scope
+
+- `Validate all formulas` — already correctly excluded from required checks (2026-07-19, PR
+  #163) because it has no `pull_request` trigger at all (`schedule` + `workflow_dispatch` only).
+  Giving it a `pull_request` trigger scoped to `Formula/**` is a separate, later decision
+  (flagged as a Long-term item in the brainstorm) — not bundled into this fix.
+- Branch-protection API changes — this SPEC is workflow-file-only; the required-contexts list
+  (`Regen vs committed`, `Check .STATUS for conflict markers`) does not change.
+- Any change to `update-formula.yml` or `docs.yml` — unrelated to this gap.
+
+## Acceptance Criteria
+
+- [ ] A PR touching only `.STATUS` (no `Formula/**`/`generator/**`) shows `Regen vs committed` as
+      a completed, green, fast (<30s) check — not "expected/waiting" — and `mergeStateStatus`
+      reports `CLEAN` without `--admin`.
+- [ ] A PR touching only `Formula/**`/`generator/**` (no `.STATUS`) shows `Check .STATUS for
+      conflict markers` as a completed, green, fast check, and merges `CLEAN` without `--admin`.
+- [ ] A PR touching neither path set (e.g. a docs-only or workflow-YAML-only change) merges
+      `CLEAN` without `--admin`.
+- [ ] A PR that *does* touch `Formula/**` with an actual drift bug still fails `Regen vs
+      committed` for real (skip logic doesn't accidentally swallow real failures) — planted-defect
+      regression test.
+- [ ] A PR that *does* introduce a conflict marker in `.STATUS` still fails `Check .STATUS for
+      conflict markers` for real — planted-defect regression test.
+- [ ] No new third-party GitHub Action dependency introduced (matches existing repo convention of
+      hand-rolled bash for this class of check — see `check-revision-bump.sh`,
+      `check-status-conflict-markers.sh`).
+
+## Resolution (see grill)
+
+All open questions resolved via [GRILL-required-checks-self-skip-2026-07-19.md](GRILL-required-checks-self-skip-2026-07-19.md):
+
+1. Diff-base resolution: extend `formula-drift.yml`'s existing "Determine revision-drift check
+   inputs" step (not a separate one).
+2. Fail closed on ambiguity — a diff-resolution error must fail the job, never silently skip.
+3. Rollout order: `status-guard.yml` self-skip fix ships first, in its own PR, as a proof of the
+   pattern; `formula-drift.yml` follows in a second PR once validated.
+4. CI-minutes cost accepted as negligible; noted for a post-rollout glance, not gated on now.
+5. `Validate all formulas` PR-trigger question stays explicitly out of scope (separate future
+   decision).


### PR DESCRIPTION
## Summary
- Adds `BRAINSTORM-required-checks-path-filtering-2026-07-19.md`, `SPEC-required-checks-self-skip-2026-07-19.md`, `GRILL-required-checks-self-skip-2026-07-19.md`.
- Design-only: no workflow changes yet. Captures the fix for PRs #162/#163/#165/#166's `--admin` pattern — path-filtered required checks (`Regen vs committed`, `Check .STATUS for conflict markers`) permanently BLOCK any PR that doesn't touch both path sets at once.
- Locked decisions (grill): job-level self-skip via `git diff --name-only`, fail-closed on ambiguity, staged rollout (`status-guard.yml` first, own PR, then `formula-drift.yml`), `Validate all formulas` PR-trigger stays out of scope.

## Test plan
- Docs-only change; no tests required. Implementation PRs will follow this SPEC's Acceptance Criteria with planted-defect E2E per `e2e-before-pr.md`.