### PR TITLE
fix(ci): make status-guard.yml self-skip instead of BLOCKED-forever

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -254,3 +254,9 @@ progress: SPEC-release-drift-gates-2026-07-16.md fully implemented and merged to
   not yet revisited). Live-verified both directions: #162/#163 (`.STATUS`-
   only) needed `--admin` since `Regen vs committed` never triggered; #165
   (`generator/**`) went `CLEAN` with no override.
+
+<<<<<<< PLANTED-DEFECT-TEST
+throwaway
+=======
+other
+>>>>>>> PLANTED-DEFECT-TEST

--- a/.STATUS
+++ b/.STATUS
@@ -1,8 +1,23 @@
 status: Active
 last_session: 2026-07-19
-milestone: release-drift-gates plan complete (Tasks 1-10 shipped) + deferred branch-protection gap closed + required-checks list corrected
+milestone: release-drift-gates plan complete (Tasks 1-10 shipped) + deferred branch-protection gap closed + required-checks list corrected + status-guard.yml self-skip fix (in progress)
 
-progress: SPEC-release-drift-gates-2026-07-16.md fully implemented and merged to main; both new CI gates live-verified; the SPEC's deferred open question (main had no required_status_checks, so CI red didn't block merge) is now closed; required-checks list corrected after PR #162 exposed a structural bug
+progress: SPEC-release-drift-gates-2026-07-16.md fully implemented and merged to main; both new CI gates live-verified; the SPEC's deferred open question (main had no required_status_checks, so CI red didn't block merge) is now closed; required-checks list corrected after PR #162 exposed a structural bug; SPEC-required-checks-self-skip-2026-07-19.md (brainstorm+grill'd) now driving — status-guard.yml's self-skip fix is in this PR (#170), formula-drift.yml's follows separately per the grill's staged-rollout decision
+
+📋 Session 2026-07-19 (cont. — driving SPEC-required-checks-self-skip-2026-07-19.md, status-guard.yml half):
+- PR #170 (in progress): `status-guard.yml`'s `pull_request` trigger dropped its `.STATUS` path
+  filter (unconditional now); a new "Determine whether .STATUS changed" step diffs against the
+  PR base ref / push `before` and skips the real conflict-marker check fast when `.STATUS` wasn't
+  touched — fail-closed (job fails, doesn't skip) if the diff itself can't be resolved. Modeled on
+  `formula-drift.yml`'s existing "Determine revision-drift check inputs" step for the PR-vs-push
+  event branching, per the grill's Decision 1 reasoning (applied here to the *pattern*, not the
+  literal step, since `status-guard.yml` had no equivalent step to extend).
+- E2E case 1 (path not touched) verified live on this PR: initial commit touched only the
+  workflow YAML; job log shows "`.STATUS not touched — skipping the real check.`" and the
+  conflict-marker step never ran — job still completed green, fast.
+- E2E cases 2 (real check still runs when `.STATUS` is touched — this very commit) and 3 (planted
+  conflict-marker still fails) to follow in this same PR before merge, per
+  `SPEC-required-checks-self-skip-2026-07-19.md`'s Acceptance Criteria.
 
 📋 Session 2026-07-19 (cont. — fixing the required-checks list):
 - PR #162 (main, merged with `--admin`) hit `mergeStateStatus: BLOCKED` on green CI: `Regen vs

--- a/.STATUS
+++ b/.STATUS
@@ -12,12 +12,18 @@ progress: SPEC-release-drift-gates-2026-07-16.md fully implemented and merged to
   `formula-drift.yml`'s existing "Determine revision-drift check inputs" step for the PR-vs-push
   event branching, per the grill's Decision 1 reasoning (applied here to the *pattern*, not the
   literal step, since `status-guard.yml` had no equivalent step to extend).
-- E2E case 1 (path not touched) verified live on this PR: initial commit touched only the
-  workflow YAML; job log shows "`.STATUS not touched — skipping the real check.`" and the
-  conflict-marker step never ran — job still completed green, fast.
-- E2E cases 2 (real check still runs when `.STATUS` is touched — this very commit) and 3 (planted
-  conflict-marker still fails) to follow in this same PR before merge, per
-  `SPEC-required-checks-self-skip-2026-07-19.md`'s Acceptance Criteria.
+- All 3 E2E cases verified live on PR #170, per `SPEC-required-checks-self-skip-2026-07-19.md`'s
+  Acceptance Criteria:
+  1. Path not touched (workflow-YAML-only commit): job log shows "`.STATUS not touched —
+     skipping the real check.`", conflict-marker step never ran, job green and fast.
+  2. Path touched, real content (`.STATUS` update commit): `run_check=true`, real script ran,
+     "`✅ .STATUS: no conflict markers.`".
+  3. Path touched, planted defect (throwaway conflict-marker commit): real script ran, correctly
+     failed — "`❌ conflict marker(s) found in .STATUS`", job conclusion `failure`. Reverted
+     before merge (`git revert`, not force-push/history-rewrite).
+- `status-guard.yml` half of `SPEC-required-checks-self-skip-2026-07-19.md` complete. Second half
+  (`formula-drift.yml`, extending its existing "Determine revision-drift check inputs" step per
+  the grill's Decision 1) is a separate future PR — not started.
 
 📋 Session 2026-07-19 (cont. — fixing the required-checks list):
 - PR #162 (main, merged with `--admin`) hit `mergeStateStatus: BLOCKED` on green CI: `Regen vs

--- a/.STATUS
+++ b/.STATUS
@@ -254,9 +254,3 @@ progress: SPEC-release-drift-gates-2026-07-16.md fully implemented and merged to
   not yet revisited). Live-verified both directions: #162/#163 (`.STATUS`-
   only) needed `--admin` since `Regen vs committed` never triggered; #165
   (`generator/**`) went `CLEAN` with no override.
-
-<<<<<<< PLANTED-DEFECT-TEST
-throwaway
-=======
-other
->>>>>>> PLANTED-DEFECT-TEST

--- a/.github/workflows/status-guard.yml
+++ b/.github/workflows/status-guard.yml
@@ -3,6 +3,13 @@
 # .STATUS is hand-edited frequently, often across concurrent worktrees/PRs.
 # This fails CI if a literal git merge-conflict marker (<<<<<<<, =======,
 # >>>>>>>) was committed by mistake.
+#
+# This check is required by main's branch protection (SPEC-release-drift-gates-2026-07-16.md).
+# Required checks must report on every PR — GitHub has no path-awareness of its own, so a
+# `pull_request: paths: .STATUS` trigger left the job permanently "expected/waiting" (and the PR
+# permanently BLOCKED) on any PR that doesn't touch .STATUS. Fixed per
+# SPEC-required-checks-self-skip-2026-07-19.md: the trigger is unconditional on pull_request, and
+# the job itself decides fast whether to run the real check or skip.
 
 name: Status Guard
 
@@ -11,15 +18,55 @@ on:
     paths:
       - '.STATUS'
   pull_request:
-    paths:
-      - '.STATUS'
 
 jobs:
   conflict-markers:
     name: Check .STATUS for conflict markers
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 (full history) — the self-skip check below diffs .STATUS against the PR
+      # base ref / previous push commit, which the default shallow (depth-1) checkout doesn't have.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Base ref differs by trigger, mirroring formula-drift.yml's "Determine revision-drift check
+      # inputs" step: pull_request compares against the PR's base commit; push compares against
+      # the previous tip (github.event.before). A push event for a brand-new branch has `before`
+      # as the all-zeros sentinel — skip gracefully rather than error, since there's no real
+      # "before" state to diff against.
+      #
+      # Fail-closed contract: if base-ref resolution or the diff itself errors for any other
+      # reason, this step FAILS (not skips) — an unresolvable "what changed?" must never be
+      # silently treated as "nothing changed," or this required check would always report green
+      # while checking nothing.
+      - name: Determine whether .STATUS changed
+        id: status_inputs
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
+          else
+            base_sha="${{ github.event.before }}"
+          fi
+
+          if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            echo "New branch / no prior state — skipping (nothing to diff against)."
+            echo "run_check=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! changed_files=$(git diff --name-only "$base_sha"...HEAD 2>&1); then
+            echo "::error::Could not diff against base $base_sha — failing closed: $changed_files"
+            exit 1
+          fi
+
+          if echo "$changed_files" | grep -qx '\.STATUS'; then
+            echo "run_check=true" >> "$GITHUB_OUTPUT"
+          else
+            echo ".STATUS not touched — skipping the real check."
+            echo "run_check=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Check .STATUS for conflict markers
+        if: steps.status_inputs.outputs.run_check == 'true'
         run: bash generator/check-status-conflict-markers.sh .STATUS


### PR DESCRIPTION
## Summary
- First half of SPEC-required-checks-self-skip-2026-07-19.md (staged rollout, status-guard.yml first per the grill's Decision 3).
- `status-guard.yml`'s `pull_request` trigger drops its `.STATUS` path filter; a new job-level step determines whether `.STATUS` actually changed and skips the real check fast when it didn't — fail-closed if diff-base resolution itself errors.

## E2E plan (per e2e-before-pr.md, executed live on this PR before marking ready)
- [ ] This commit (workflow-only, no `.STATUS` touch) — confirms the skip path: check reports fast + green without running the real script.
- [ ] Follow-up commit updating `.STATUS` — confirms the real check still runs when the path is touched.
- [ ] Throwaway planted-defect commit (conflict marker in `.STATUS`) — confirms it still fails for real; reverted before merge.

Draft until all three are observed.