### PR TITLE
docs: fix stale 14/15-formula counts, add agy/obsidian-cli-ops to inventory

### DIFF
--- a/.STATUS
+++ b/.STATUS
@@ -227,7 +227,7 @@ progress: SPEC-release-drift-gates-2026-07-16.md fully implemented and merged to
 - Merged PR #91 (+2875/-404, 50 files), PR #92 (docs sync), PR #93 (.STATUS), PR #94 (workflow fix)
 - Cleaned up: worktree removed, 10+ stale remote branches deleted
 
-📊 Tap Inventory: 14 formulas + 2 casks (14/14 pass brew audit --strict)
+📊 Tap Inventory: 16 formulas + 2 casks (16/16 pass brew audit --strict)
 
 | Formula | Type | CI Caller | Audit Status |
 |---------|------|-----------|-------------|
@@ -239,11 +239,13 @@ progress: SPEC-release-drift-gates-2026-07-16.md fully implemented and merged to
 | workflow | plugin (generated) | Yes | CLEAN |
 | folio | plugin (generated) | Yes | CLEAN (rev 1 — PR #143 registration + PR #147 revision-bump merged) |
 | aiterm | python | Yes | CLEAN |
+| agy | python | Yes | CLEAN |
 | atlas | node | Yes | CLEAN |
 | nexus-cli | python | Yes | CLEAN |
 | flow-cli | shell | Yes | CLEAN |
 | examark | npm | Yes | CLEAN |
 | mcp-bridge | node | Yes | CLEAN |
+| obsidian-cli-ops | python | Yes | CLEAN |
 | scribe-cli | swift | No | CLEAN (placeholder SHA) |
 
 🎯 Next Action:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ A Homebrew tap (`brew tap data-wise/tap`) distributing CLI tools, Claude Code pl
 
 ## Repository Layout
 
-- `Formula/*.rb` — 14 Homebrew formulas (CLI tools, plugins)
+- `Formula/*.rb` — 16 Homebrew formulas (CLI tools, plugins)
 - `Casks/*.rb` — Homebrew casks (scribe, scribe-dev)
 - `generator/` — Python formula generator for plugin formulas
   - `generate.py` — Reads manifest, produces `Formula/*.rb`
@@ -92,7 +92,7 @@ When editing a plugin formula, edit `manifest.json` + `blocks/` then regenerate 
 
 Other Data-Wise repos call `.github/workflows/update-formula.yml` on release. It accepts `formula_name`, `version`, `sha256`, `source_type` (github|pypi|npm|cran), and `auto_merge`. The workflow uses `sed` to update version/SHA in the formula file, then either pushes directly to main or creates a PR. Authentication uses the GitHub App "Data-Wise Homebrew Automation" (App ID: 2874502) with PAT fallback.
 
-Weekly validation (`validate-formulas.yml`) runs `brew style` + `ruby -c` on all 14 formulas every Monday at 06:00 UTC.
+Weekly validation (`validate-formulas.yml`) runs `brew style` + `ruby -c` on all 16 formulas every Monday at 06:00 UTC.
 
 ## Cask Conventions
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The generator reads `generator/manifest.json` and composes bash blocks from `gen
 ## CI/CD
 
 - **update-formula.yml** — Reusable workflow called by project repos on release. Supports `github`, `pypi`, `npm`, and `cran` source types. Uses GitHub App token (Data-Wise Homebrew Automation) with PAT fallback.
-- **validate-formulas.yml** — Weekly `brew style` + `ruby -c` validation of all 14 formulas (Monday 06:00 UTC).
+- **validate-formulas.yml** — Weekly `brew style` + `ruby -c` validation of all 16 formulas (Monday 06:00 UTC).
 
 ## More Info
 

--- a/docs/ci/validation.md
+++ b/docs/ci/validation.md
@@ -10,7 +10,7 @@ Runs every Monday at 06:00 UTC via `validate-formulas.yml`. Can also be triggere
 
 ### brew audit --strict
 
-Runs `brew audit --strict` on all 14 formulas using tap-qualified names (`data-wise/tap/<name>`). Reports pass/fail count and lists any failing formulas.
+Runs `brew audit --strict` on all 16 formulas using tap-qualified names (`data-wise/tap/<name>`). Reports pass/fail count and lists any failing formulas.
 
 ### ruby -c
 

--- a/docs/formulas/cli-tools.md
+++ b/docs/formulas/cli-tools.md
@@ -78,6 +78,16 @@ brew install data-wise/tap/nexus-cli
 
 **Type:** Python virtualenv | **Source:** PyPI
 
+## obsidian-cli-ops
+
+Obsidian vault CLI + MCP server (isolated venv, Rust deps).
+
+```bash
+brew install data-wise/tap/obsidian-cli-ops
+```
+
+**Type:** Python virtualenv | **Source:** GitHub
+
 ## scribe-cli
 
 Scribe document conversion CLI.

--- a/docs/formulas/index.md
+++ b/docs/formulas/index.md
@@ -1,18 +1,18 @@
 # Formula Overview
 
-The tap contains 15 formulas and 2 casks, organized into three categories:
+The tap contains 16 formulas and 2 casks, organized into three categories:
 
 ## Categories
 
 ### 1. Python Virtualenv Formulas
 
-**agy**, **aiterm**, **nexus-cli**
+**agy**, **aiterm**, **nexus-cli**, **obsidian-cli-ops**
 
 Use `Language::Python::Virtualenv`, depend on `python@3.12`. Installed via virtualenv patterns.
 
 ### 2. Claude Code Plugin Formulas
 
-**craft**, **himalaya-mcp**, **rforge**, **rforge-orchestrator**, **scholar**, **workflow**
+**craft**, **himalaya-mcp**, **rforge**, **rforge-orchestrator**, **scholar**, **workflow**, **folio**
 
 These are [generated](../generator/index.md) from a single manifest. They share a complex install pattern:
 
@@ -29,7 +29,7 @@ Direct file installation with minimal logic. Each has its own URL pattern and bu
 
 ## Audit Status
 
-All 14 formulas pass `brew audit --strict` and `brew style`.
+All 16 formulas pass `brew audit --strict` and `brew style`.
 
 !!! note "Audit reads from tap directory"
     `brew audit` reads formulas from `/opt/homebrew/Library/Taps/data-wise/homebrew-tap/`, not the current working directory. To audit local changes, copy formulas to the tap dir first.


### PR DESCRIPTION
## Summary
- `Formula/` has 16 `.rb` files, but several docs still said 14 (or 15): `docs/ci/index.md`, `docs/ci/validation.md`, `docs/formulas/index.md`, `README.md`, `CLAUDE.md`.
- `agy` and `obsidian-cli-ops` were verified as legitimate formulas — both added via `git log --follow`, both `github-actions[bot]`-authored release commits (confirming CI-caller status via `update-formula.yml`), both pass `brew audit --strict data-wise/tap/<name>` clean.
- Added both to `.STATUS`'s Tap Inventory table and to `docs/formulas/cli-tools.md` (agy was already documented there; obsidian-cli-ops was missing entirely). Also added `folio` to `docs/formulas/index.md`'s plugin-category list (same missing-entry pattern).
- No changes to Formula files, generator, or CI workflow files — pure docs/inventory currency fix, unrelated to the same-day branch-protection/CI self-skip work (PRs #170-#172).

## Not touched (flagged, not fixed)
- `docs/generator/help.md`, and `CLAUDE.md`'s "manifest.json — Single source of truth for all 14 formulas" line refer to `generator/manifest.json`'s formula count, which is a *different* fact from the `Formula/*.rb` file count — the manifest has an `examify` entry with no corresponding `Formula/examify.rb`, and does not track `obsidian-cli-ops` at all (hand-maintained, not generator-tracked). Fixing that would require reconciling the manifest itself, out of scope here.
- `ORCHESTRATE-homebrew-refactor.md`'s "14 formulas" is a historical point-in-time record of a past refactor, not live documentation — left as-is.
- `README.md`'s "More Info" project list is a curated subset (already missing several formulas beyond just agy/obsidian-cli-ops) — not part of the count-drift fix.

## Test plan
- [x] `mkdocs build --strict` — 0 warnings
- [x] `brew audit --strict data-wise/tap/agy` — clean
- [x] `brew audit --strict data-wise/tap/obsidian-cli-ops` — clean