### PR TITLE
test: E2E verify gh pr merge --auto mechanics (throwaway)

### DIFF
--- a/.github/E2E-AUTOMERGE-TEST.md
+++ b/.github/E2E-AUTOMERGE-TEST.md
@@ -1,0 +1,3 @@
+Throwaway file to E2E-test `gh pr merge --auto --squash` mechanics for the
+update-formula.yml auto_merge:true fix (fix/update-formula-branch-protection).
+Deleted immediately after the auto-merge is confirmed to complete on its own.


### PR DESCRIPTION
Throwaway PR to E2E-test the exact `gh pr merge --auto --squash` command the update-formula.yml fix (fix/update-formula-branch-protection) now relies on for its `auto_merge: true` path. Will be reverted immediately after confirming the auto-merge completes without manual intervention.