### PR TITLE
test: remove E2E-AUTOMERGE-TEST.md (auto-merge mechanics confirmed)

### DIFF
--- a/.github/E2E-AUTOMERGE-TEST.md
+++ b/.github/E2E-AUTOMERGE-TEST.md
@@ -1,3 +1,0 @@
-Throwaway file to E2E-test `gh pr merge --auto --squash` mechanics for the
-update-formula.yml auto_merge:true fix (fix/update-formula-branch-protection).
-Deleted immediately after the auto-merge is confirmed to complete on its own.


### PR DESCRIPTION
Cleanup: removes the throwaway file added by #174, which was used to E2E-verify `gh pr merge --auto --squash` mechanics for the update-formula.yml fix (#175). Confirmed working — #174 auto-merged on its own.