### PR TITLE
atlas: fix stale caveats (XDG default, drop v0.9.0 block)

### DIFF
--- a/Formula/atlas.rb
+++ b/Formula/atlas.rb
@@ -8,6 +8,7 @@ class Atlas < Formula
   url "https://github.com/Data-Wise/atlas/archive/refs/tags/v0.15.0.tar.gz"
   sha256 "abd37d25fdadeca2957c9100fec4c448c8301a04b87d4696a5094261c035961b"
   license "MIT"
+  revision 1
 
   depends_on "python@3.12" => :build
   depends_on "node"
@@ -34,15 +35,12 @@ class Atlas < Formula
         atlas stats                   # Session analytics
         atlas dash                    # Interactive dashboard
 
-      New in v0.9.0:
-        React Ink TUI replaces blessed (73% code reduction)
-        Multi-panel dashboard: Tab cycles SINGLE/SPLIT/TRIPLE layouts
-        MCP Server with 10 tools for Claude integration
-        atlas plan                    # Guided daily planning
-
       Shell completions have been installed for bash, zsh, and fish.
 
-      Data is stored in: ~/.atlas/
+      Data is stored in $XDG_CONFIG_HOME/atlas (or ~/.config/atlas) on new
+      installs; existing ~/.atlas installs keep working unchanged until you
+      run `atlas migrate --xdg`. Run `atlas doctor` to check which location
+      is active.
 
       Documentation: https://data-wise.github.io/atlas/
     EOS

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -396,8 +396,8 @@
       "homepage": "https://github.com/Data-Wise/atlas",
       "source": "github",
       "repo": "Data-Wise/atlas",
-      "version": "0.14.0",
-      "sha256": "e62bcf2e6f9902ed47d416310f943ebcb5cb53475bc9c530d0e2379e69f0dd04",
+      "version": "0.15.0",
+      "sha256": "abd37d25fdadeca2957c9100fec4c448c8301a04b87d4696a5094261c035961b",
       "generated": false,
       "revision": 1
     },

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -218,7 +218,7 @@
     },
     "rforge": {
       "type": "claude-plugin",
-      "desc": "R package ecosystem orchestrator \u2014 42 commands \u2014 Claude Code plugin",
+      "desc": "R package ecosystem orchestrator — 42 commands — Claude Code plugin",
       "homepage": "https://github.com/Data-Wise/rforge",
       "source": "github",
       "repo": "Data-Wise/rforge",
@@ -310,7 +310,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "\u26a0\ufe0f  DEPRECATED \u2014 This formula is no longer maintained.\n\nThe plugin has been renamed to `rforge` and now lives in its own\nrepository. Migrate with:\n\n    brew uninstall data-wise/tap/rforge-orchestrator\n    rm -rf ~/.claude/plugins/rforge-orchestrator\n    brew install --HEAD data-wise/tap/rforge\n\nThe new formula installs to ~/.claude/plugins/rforge and ships\nv1.2.0 features (R-aware PreToolUse hook, marketplace install,\nvalidation skills, 15 commands).\n\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nLegacy install info (for users on this deprecated formula):\n\nThe RForge Orchestrator plugin has been installed to:\n  ~/.claude/plugins/rforge-orchestrator\n\nIf not auto-enabled, run:\n  claude plugin install rforge-orchestrator@local-plugins\n\nRequirements:\n  - Claude Code CLI must be installed\n  - RForge MCP server must be configured in ~/.claude/settings.json\n\nAvailable commands (v0.1.0 had only these three):\n  /rforge:analyze  - Analyze R project and recommend tools\n  /rforge:quick    - Quick project analysis\n  /rforge:thorough - Thorough multi-stage analysis\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/rforge-orchestrator && ( cd $(brew --prefix)/opt/rforge-orchestrator/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge-orchestrator && tar xf - )\n\nFor the new plugin and full v1.2.0 docs:\n  https://github.com/Data-Wise/rforge"
+      "caveats_extra": "⚠️  DEPRECATED — This formula is no longer maintained.\n\nThe plugin has been renamed to `rforge` and now lives in its own\nrepository. Migrate with:\n\n    brew uninstall data-wise/tap/rforge-orchestrator\n    rm -rf ~/.claude/plugins/rforge-orchestrator\n    brew install --HEAD data-wise/tap/rforge\n\nThe new formula installs to ~/.claude/plugins/rforge and ships\nv1.2.0 features (R-aware PreToolUse hook, marketplace install,\nvalidation skills, 15 commands).\n\n──────────────────────────────────────────────────────\n\nLegacy install info (for users on this deprecated formula):\n\nThe RForge Orchestrator plugin has been installed to:\n  ~/.claude/plugins/rforge-orchestrator\n\nIf not auto-enabled, run:\n  claude plugin install rforge-orchestrator@local-plugins\n\nRequirements:\n  - Claude Code CLI must be installed\n  - RForge MCP server must be configured in ~/.claude/settings.json\n\nAvailable commands (v0.1.0 had only these three):\n  /rforge:analyze  - Analyze R project and recommend tools\n  /rforge:quick    - Quick project analysis\n  /rforge:thorough - Thorough multi-stage analysis\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/rforge-orchestrator && ( cd $(brew --prefix)/opt/rforge-orchestrator/libexec && tar cf - . ) | ( cd ~/.claude/plugins/rforge-orchestrator && tar xf - )\n\nFor the new plugin and full v1.2.0 docs:\n  https://github.com/Data-Wise/rforge"
     },
     "workflow": {
       "type": "claude-plugin",
@@ -398,7 +398,8 @@
       "repo": "Data-Wise/atlas",
       "version": "0.14.0",
       "sha256": "e62bcf2e6f9902ed47d416310f943ebcb5cb53475bc9c530d0e2379e69f0dd04",
-      "generated": false
+      "generated": false,
+      "revision": 1
     },
     "examark": {
       "type": "node-npm",


### PR DESCRIPTION
## Summary
- `Data is stored in: ~/.atlas/` was wrong as of atlas v0.15.0 — new installs default to `$XDG_CONFIG_HOME/atlas` (or `~/.config/atlas`), not `~/.atlas`. Replaced with accurate dual-path phrasing + a pointer to `atlas doctor`.
- Dropped the `New in v0.9.0` block — 6 versions stale, and inconsistent with the dynamic `Atlas v#{version} has been installed!` line above it.

Found during [PR #179](https://github.com/Data-Wise/homebrew-tap/pull/179) review; out of that PR's version-bump scope, fixed here.

## Test plan
- [x] `ruby -c Formula/atlas.rb`: syntax OK
- [x] `brew style Formula/atlas.rb`: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)