### PR TITLE
atlas: clear stale revision field

### DIFF
--- a/Formula/atlas.rb
+++ b/Formula/atlas.rb
@@ -8,7 +8,6 @@ class Atlas < Formula
   url "https://github.com/Data-Wise/atlas/archive/refs/tags/v0.16.0.tar.gz"
   sha256 "cdbcfeb171d4f048856d16f30a6c5891deaa5bdb64745f1984320f6dd1edf7a3"
   license "MIT"
-  revision 1
 
   depends_on "python@3.12" => :build
   depends_on "node"

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -398,8 +398,7 @@
       "repo": "Data-Wise/atlas",
       "version": "0.16.0",
       "sha256": "cdbcfeb171d4f048856d16f30a6c5891deaa5bdb64745f1984320f6dd1edf7a3",
-      "generated": false,
-      "revision": 1
+      "generated": false
     },
     "examark": {
       "type": "node-npm",


### PR DESCRIPTION
## Summary
- Removes the leftover \`revision 1\` from \`Formula/atlas.rb\` and \`generator/manifest.json\`'s atlas entry
- That revision was needed for the v0.15.0 caveats-only fix (content changed, no version bump); now that both files track v0.16.0, the tiebreaker is unnecessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)