### PR TITLE
fix(ci): self-skip fail-closed logic no longer breaks on force-push

### DIFF
--- a/.github/workflows/formula-drift.yml
+++ b/.github/workflows/formula-drift.yml
@@ -44,14 +44,19 @@ jobs:
       # branch has `before` as the all-zeros sentinel — skip gracefully rather than error, since
       # there's no real "before" state to diff against.
       #
-      # Fail-closed contract: if base-ref resolution or the diff itself errors for any other
-      # reason, this step FAILS (not skips) — an unresolvable "what changed?" must never be
-      # silently treated as "nothing changed," or this required check would always report green
-      # while checking nothing.
+      # Fail-closed contract: if the diff can't be resolved for an UNEXPLAINED reason, this step
+      # FAILS (not skips) — an unresolvable "what changed?" must never be silently treated as
+      # "nothing changed," or this required check would always report green while checking
+      # nothing. The one identifiable, non-ambiguous exception: a force-pushed branch orphans the
+      # push event's `before` SHA (it's simply gone, not just hard to diff), which is a routine
+      # rebase side effect, not genuine uncertainty — in that case we know exactly why the diff
+      # can't run.
       #
-      # run_check gates ALL the real checks below (drift regen, no-symlink contract,
-      # revision-bump) — none of them are relevant unless generator/** or Formula/** actually
-      # changed since base.
+      # run_check gates the two base-independent real checks (drift regen, no-symlink contract) —
+      # both just inspect the current committed state, so they can safely run even when we can't
+      # tell what changed since base. revision_bump_runnable additionally requires a resolvable
+      # base_sha (check-revision-bump.sh diffs against it directly and errors without one), so the
+      # unreachable-base fallback below enables run_check but NOT revision_bump_runnable.
       - name: Determine formula-drift check inputs
         id: drift_inputs
         run: |
@@ -66,6 +71,15 @@ jobs:
           if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
             echo "New branch / no prior state — skipping (nothing to diff against)."
             echo "run_check=false" >> "$GITHUB_OUTPUT"
+            echo "revision_bump_runnable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            echo "Base $base_sha is unreachable (likely a force-push/rebase orphaned it) —"
+            echo "running the base-independent checks rather than guessing what changed."
+            echo "run_check=true" >> "$GITHUB_OUTPUT"
+            echo "revision_bump_runnable=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -79,9 +93,11 @@ jobs:
 
           if echo "$changed_files" | grep -qE '^(generator/|Formula/)'; then
             echo "run_check=true" >> "$GITHUB_OUTPUT"
+            echo "revision_bump_runnable=true" >> "$GITHUB_OUTPUT"
           else
             echo "Neither generator/** nor Formula/** touched — skipping the real checks."
             echo "run_check=false" >> "$GITHUB_OUTPUT"
+            echo "revision_bump_runnable=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check formula drift (regen vs committed)
@@ -93,7 +109,7 @@ jobs:
         run: bash tests/test_no_symlink_install.sh
 
       - name: Revision-drift check (formula content changed without version/revision bump)
-        if: steps.drift_inputs.outputs.run_check == 'true'
+        if: steps.drift_inputs.outputs.run_check == 'true' && steps.drift_inputs.outputs.revision_bump_runnable == 'true'
         env:
           PR_LABELS: ${{ steps.drift_inputs.outputs.labels }}
         run: bash generator/check-revision-bump.sh "${{ steps.drift_inputs.outputs.base_sha }}"

--- a/.github/workflows/status-guard.yml
+++ b/.github/workflows/status-guard.yml
@@ -36,10 +36,14 @@ jobs:
       # as the all-zeros sentinel — skip gracefully rather than error, since there's no real
       # "before" state to diff against.
       #
-      # Fail-closed contract: if base-ref resolution or the diff itself errors for any other
-      # reason, this step FAILS (not skips) — an unresolvable "what changed?" must never be
-      # silently treated as "nothing changed," or this required check would always report green
-      # while checking nothing.
+      # Fail-closed contract: if the diff can't be resolved for an UNEXPLAINED reason, this step
+      # FAILS (not skips) — an unresolvable "what changed?" must never be silently treated as
+      # "nothing changed," or this required check would always report green while checking
+      # nothing. The one identifiable, non-ambiguous exception: a force-pushed branch orphans the
+      # push event's `before` SHA (it's simply gone, not just hard to diff), which is a routine
+      # rebase side effect, not genuine uncertainty — in that case we know exactly why the diff
+      # can't run, so fall back to running the real check (base-independent — it just scans
+      # .STATUS directly) rather than failing the job outright.
       - name: Determine whether .STATUS changed
         id: status_inputs
         run: |
@@ -52,6 +56,13 @@ jobs:
           if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
             echo "New branch / no prior state — skipping (nothing to diff against)."
             echo "run_check=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            echo "Base $base_sha is unreachable (likely a force-push/rebase orphaned it) —"
+            echo "running the real check rather than guessing what changed."
+            echo "run_check=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

Both `status-guard.yml`'s and `formula-drift.yml`'s self-skip logic (SPEC-required-checks-self-skip-2026-07-19.md) diffs against a `before`/base SHA to decide whether to run the real check. A force-pushed/rebased branch orphans that SHA — it's simply gone, not just hard to diff — and both workflows treated that identically to any other diff failure: fail closed (exit 1).

Hit live on #173 this session: rebasing that PR's branch and force-pushing produced a same-named FAILURE check-run (from the push-triggered run, orphaned `before`) sitting alongside the correct passing pull_request-triggered run, which kept `mergeStateStatus: BLOCKED` even though the actual gating check had passed. Worked around there with a non-force follow-up push; this PR fixes the workflow itself.

## Fix

Both workflows now check whether `base_sha` resolves to a real commit object (`git cat-file -e "$base_sha^{commit}"`) before attempting the diff:

- **Unreachable** (force-push case — identifiable, not genuine ambiguity) → run the real check instead of failing the job.
- **Any other diff failure** → still fails closed exactly as before. This only changes behavior for the one now-distinguishable force-push case.

`status-guard.yml`'s real check (`check-status-conflict-markers.sh`) is base-independent (scans `.STATUS` directly), so it can always run safely in the fallback.

`formula-drift.yml` is more nuanced — `check-drift.sh` and `test_no_symlink_install.sh` are base-independent and now run in the fallback, but `check-revision-bump.sh` genuinely requires a resolvable base to diff against (it errors without one). It gets its own `revision_bump_runnable` gate and is skipped, not force-passed, when base is unreachable — the one real, correctly-attributed gap this leaves (narrow: only affects a force-pushed PR that also touches `Formula/**`/`generator/**`).

## Test plan

- `actionlint` — clean on both files.
- Simulated a fabricated unreachable SHA locally: `cat-file -e` correctly identifies it as unreachable; a real reachable SHA still proceeds through the normal diff path unchanged.
- Planted-defect check: `check-status-conflict-markers.sh` still fails on a real conflict marker regardless of which path (normal diff vs. fallback) enabled it — the fallback only changes *whether* the check runs, never *what* it detects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)