### PR TITLE
docs: fix pre-existing stale formula count in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ A Homebrew tap (`brew tap data-wise/tap`) distributing CLI tools, Claude Code pl
 - `Casks/*.rb` — Homebrew casks (scribe, scribe-dev)
 - `generator/` — Python formula generator for plugin formulas
   - `generate.py` — Reads manifest, produces `Formula/*.rb`
-  - `manifest.json` — Single source of truth for all 14 formulas
+  - `manifest.json` — Single source of truth for all 15 formulas
   - `blocks/` — Composable bash/ruby fragments (symlink, schema-cleanup, marketplace, etc.)
 - `docs/` — MkDocs Material documentation site (adhd-focus preset)
 - `mkdocs.yml` — MkDocs configuration


### PR DESCRIPTION
## Summary
- One-line follow-up to #195: `CLAUDE.md` said `manifest.json` was "single source of truth for all 14 formulas" — was already stale before #195 (manifest had 16 entries pre-removal, now 15), never actually 14. Caught in review of #195 but the fix commit missed that PR's squash-merge (pushed after merge fired).

## Test plan
- [x] `python3 -c "import json; print(len(json.load(open('generator/manifest.json'))['formulas']))"` → 15, matches the new line

🤖 Generated with [Claude Code](https://claude.com/claude-code)