### PR TITLE
Fix himalaya hook installation layout

### DIFF
--- a/Formula/himalaya-mcp.rb
+++ b/Formula/himalaya-mcp.rb
@@ -8,6 +8,7 @@ class HimalayaMcp < Formula
   url "https://github.com/Data-Wise/himalaya-mcp/archive/refs/tags/v2.0.4.tar.gz"
   sha256 "889e4ff028d2b95172490388228369fa917cf5c1d98d3d1ece043b9fae0ed481"
   license "MIT"
+  revision 1
 
   depends_on "himalaya"
   depends_on "jq"
@@ -22,19 +23,14 @@ class HimalayaMcp < Formula
 
     mkdir_p libexec/".claude-plugin"
     cp "himalaya-mcp-plugin/.claude-plugin/plugin.json", libexec/".claude-plugin/plugin.json"
-    if (buildpath/"himalaya-mcp-plugin/hooks").directory?
-      cp_r "himalaya-mcp-plugin/hooks", libexec/"hooks"
-    else
-      # Keep older release tarballs installable while the plugin moves hooks
-      # to the documented plugin-root location.
-      cp_r "himalaya-mcp-plugin/.claude-plugin/hooks", libexec/".claude-plugin/hooks"
-    end
     cp ".claude-plugin/marketplace.json", libexec/".claude-plugin/marketplace.json"
     libexec.install ".mcp.json" if (buildpath/".mcp.json").exist?
     libexec.install "dist" if (buildpath/"dist").exist?
     libexec.install "man" if (buildpath/"man").exist?
     cp_r "himalaya-mcp-plugin/skills", libexec/"skills"
     cp_r "himalaya-mcp-plugin/agents", libexec/"agents"
+    cp_r "himalaya-mcp-plugin/.claude-plugin/hooks", libexec/".claude-plugin/hooks" if (buildpath/"himalaya-mcp-plugin/.claude-plugin/hooks").exist?
+    cp_r "himalaya-mcp-plugin/hooks", libexec/"hooks" if (buildpath/"himalaya-mcp-plugin/hooks").exist?
 
     # Install groff man pages to share/man/manN/
     man1.install Dir.glob("#{libexec}/man/man1/*") if (libexec/"man/man1").exist?
@@ -319,10 +315,12 @@ class HimalayaMcp < Formula
 
   test do
     assert_path_exists libexec/".claude-plugin/plugin.json"
-    hooks_dir = libexec/"hooks"
-    hooks_dir = libexec/".claude-plugin/hooks" unless hooks_dir.directory?
-    assert_path_exists hooks_dir/"session-start.sh"
-    assert_path_exists hooks_dir/"pre-send.sh"
+    hook_path = ".claude-plugin/hooks/session-start.sh"
+    hook_path = "hooks/session-start.sh" unless (libexec/".claude-plugin/hooks/session-start.sh").exist?
+    assert_path_exists libexec/hook_path
+    hook_path = ".claude-plugin/hooks/pre-send.sh"
+    hook_path = "hooks/pre-send.sh" unless (libexec/".claude-plugin/hooks/pre-send.sh").exist?
+    assert_path_exists libexec/hook_path
     assert_path_exists bin/"himalaya-mcp"
     assert_path_exists libexec/"dist/index.js"
     assert_predicate libexec/"skills", :directory?

--- a/Formula/himalaya-mcp.rb
+++ b/Formula/himalaya-mcp.rb
@@ -22,7 +22,13 @@ class HimalayaMcp < Formula
 
     mkdir_p libexec/".claude-plugin"
     cp "himalaya-mcp-plugin/.claude-plugin/plugin.json", libexec/".claude-plugin/plugin.json"
-    cp_r "himalaya-mcp-plugin/.claude-plugin/hooks", libexec/".claude-plugin/hooks"
+    if (buildpath/"himalaya-mcp-plugin/hooks").directory?
+      cp_r "himalaya-mcp-plugin/hooks", libexec/"hooks"
+    else
+      # Keep older release tarballs installable while the plugin moves hooks
+      # to the documented plugin-root location.
+      cp_r "himalaya-mcp-plugin/.claude-plugin/hooks", libexec/".claude-plugin/hooks"
+    end
     cp ".claude-plugin/marketplace.json", libexec/".claude-plugin/marketplace.json"
     libexec.install ".mcp.json" if (buildpath/".mcp.json").exist?
     libexec.install "dist" if (buildpath/"dist").exist?
@@ -313,8 +319,10 @@ class HimalayaMcp < Formula
 
   test do
     assert_path_exists libexec/".claude-plugin/plugin.json"
-    assert_path_exists libexec/".claude-plugin/hooks/session-start.sh"
-    assert_path_exists libexec/".claude-plugin/hooks/pre-send.sh"
+    hooks_dir = libexec/"hooks"
+    hooks_dir = libexec/".claude-plugin/hooks" unless hooks_dir.directory?
+    assert_path_exists hooks_dir/"session-start.sh"
+    assert_path_exists hooks_dir/"pre-send.sh"
     assert_path_exists bin/"himalaya-mcp"
     assert_path_exists libexec/"dist/index.js"
     assert_predicate libexec/"skills", :directory?

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -474,13 +474,21 @@ def generate_formula(formula_name, config, defaults):
     lines.append("  test do")
     for tp in config.get("test_paths", []):
         if isinstance(tp, dict):
-            path = tp["path"]
             tp_type = tp["type"]
             if tp_type == "directory":
+                path = tp["path"]
                 lines.append(f'    assert_predicate libexec/"{path}", :directory?')
             elif tp_type == "bin":
+                path = tp["path"]
                 lines.append(f'    assert_path_exists bin/"{path}"')
+            elif tp_type == "any":
+                paths = tp["paths"]
+                lines.append(f'    hook_path = "{paths[0]}"')
+                for alternative in paths[1:]:
+                    lines.append(f'    hook_path = "{alternative}" unless (libexec/"{paths[0]}").exist?')
+                lines.append('    assert_path_exists libexec/hook_path')
             else:
+                path = tp["path"]
                 lines.append(f'    assert_path_exists libexec/"{path}"')
         else:
             lines.append(f'    assert_path_exists libexec/"{tp}"')

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -63,6 +63,7 @@
       "repo": "Data-Wise/himalaya-mcp",
       "version": "2.0.4",
       "sha256": "889e4ff028d2b95172490388228369fa917cf5c1d98d3d1ece043b9fae0ed481",
+      "revision": 1,
       "bin_mkpath": true,
       "dependencies": {
         "runtime": [
@@ -88,10 +89,9 @@
         "himalaya-mcp-plugin/.claude-plugin/plugin.json": ".claude-plugin/plugin.json",
         ".claude-plugin/marketplace.json": ".claude-plugin/marketplace.json"
       },
-      "libexec_copy_map_after": {
-        "himalaya-mcp-plugin/.claude-plugin/plugin.json": {
-          "himalaya-mcp-plugin/.claude-plugin/hooks": ".claude-plugin/hooks"
-        }
+      "libexec_copy_map_optional": {
+        "himalaya-mcp-plugin/.claude-plugin/hooks": ".claude-plugin/hooks",
+        "himalaya-mcp-plugin/hooks": "hooks"
       },
       "libexec_paths": [
         ".mcp.json",
@@ -133,12 +133,18 @@
           "type": "file"
         },
         {
-          "path": ".claude-plugin/hooks/session-start.sh",
-          "type": "file"
+          "paths": [
+            ".claude-plugin/hooks/session-start.sh",
+            "hooks/session-start.sh"
+          ],
+          "type": "any"
         },
         {
-          "path": ".claude-plugin/hooks/pre-send.sh",
-          "type": "file"
+          "paths": [
+            ".claude-plugin/hooks/pre-send.sh",
+            "hooks/pre-send.sh"
+          ],
+          "type": "any"
         },
         {
           "type": "bin",


### PR DESCRIPTION
## Summary
- Copy new plugin-root hooks into libexec/hooks for future himalaya-mcp releases.
- Keep older release tarballs installable with a compatibility fallback.
- Make the formula test accept both layouts during the transition.

## Validation
- Ruby syntax check passes.
- Diff check passes.

This coordinates with Data-Wise/himalaya-mcp PR 130.