### PR TITLE
himalaya-mcp: update to v2.1.0

### DIFF
--- a/Formula/himalaya-mcp.rb
+++ b/Formula/himalaya-mcp.rb
@@ -8,7 +8,6 @@ class HimalayaMcp < Formula
   url "https://github.com/Data-Wise/himalaya-mcp/archive/refs/tags/v2.1.0.tar.gz"
   sha256 "d93b1bbc2defe099f64b5086bc2eeb215a3e70f4897ee01d7f1d4e896de9975b"
   license "MIT"
-  revision 0
 
   depends_on "himalaya"
   depends_on "jq"

--- a/Formula/himalaya-mcp.rb
+++ b/Formula/himalaya-mcp.rb
@@ -5,10 +5,10 @@
 class HimalayaMcp < Formula
   desc "Privacy-first email MCP server and Claude Code plugin wrapping himalaya CLI"
   homepage "https://github.com/Data-Wise/himalaya-mcp"
-  url "https://github.com/Data-Wise/himalaya-mcp/archive/refs/tags/v2.0.5.tar.gz"
-  sha256 "f7dd7b23d9b30e1a4c8b21e5254b97e7827109db95b68f8d3c5e2e8b454d171a"
+  url "https://github.com/Data-Wise/himalaya-mcp/archive/refs/tags/v2.1.0.tar.gz"
+  sha256 "d93b1bbc2defe099f64b5086bc2eeb215a3e70f4897ee01d7f1d4e896de9975b"
   license "MIT"
-  revision 1
+  revision 0
 
   depends_on "himalaya"
   depends_on "jq"

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -61,9 +61,9 @@
       "homepage": "https://github.com/Data-Wise/himalaya-mcp",
       "source": "github",
       "repo": "Data-Wise/himalaya-mcp",
-      "version": "2.0.5",
-      "sha256": "f7dd7b23d9b30e1a4c8b21e5254b97e7827109db95b68f8d3c5e2e8b454d171a",
-      "revision": 1,
+      "version": "2.1.0",
+      "sha256": "d93b1bbc2defe099f64b5086bc2eeb215a3e70f4897ee01d7f1d4e896de9975b",
+      "revision": 0,
       "bin_mkpath": true,
       "dependencies": {
         "runtime": [


### PR DESCRIPTION
Release v2.1.0 of himalaya-mcp (v2 CLI compatibility + multi-surface health/doctor overhaul). Updates url, sha256 (d93b1bbc2defe099f64b5086bc2eeb215a3e70f4897ee01d7f1d4e896de9975b), resets revision to 0, and syncs generator/manifest.json.