### PR TITLE
fix(craft): update stale unprotect-dev caveat text

### DIFF
--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -8,6 +8,7 @@ class Craft < Formula
   url "https://github.com/Data-Wise/craft/archive/refs/tags/v4.5.0.tar.gz"
   sha256 "21966e8cb9e518fe013d98de2edb279ec52639fe6cce4212faab12c0f5f3d948"
   license "MIT"
+  revision 1
 
   depends_on "jq"
 

--- a/Formula/craft.rb
+++ b/Formula/craft.rb
@@ -295,7 +295,7 @@ class Craft < Formula
         - ADHD-friendly task management
 
       Branch guard protects main/dev from accidental edits.
-      Bypass: /craft:git:unprotect (session-scoped)
+      Bypass: ask "unprotect dev" or "bypass branch guard" (session-scoped)
 
       Try: /craft:do "your task"
       Or:  /brainstorm

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -53,7 +53,7 @@
           "type": "directory"
         }
       ],
-      "caveats_extra": "{command_count} commands for full-stack development:\n  - Architecture & planning\n  - Code generation & refactoring\n  - Testing & CI/CD\n  - Documentation & site generation\n  - Git workflows & branch protection\n  - ADHD-friendly task management\n\nBranch guard protects main/dev from accidental edits.\nBypass: /craft:git:unprotect (session-scoped)\n\nTry: /craft:do \"your task\"\nOr:  /brainstorm\n\nAfter upgrades, sync Claude Code registry:\n  claude plugin update craft@local-plugins\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/craft && ( cd $(brew --prefix)/opt/craft/libexec && tar cf - . ) | ( cd ~/.claude/plugins/craft && tar xf - )"
+      "caveats_extra": "{command_count} commands for full-stack development:\n  - Architecture & planning\n  - Code generation & refactoring\n  - Testing & CI/CD\n  - Documentation & site generation\n  - Git workflows & branch protection\n  - ADHD-friendly task management\n\nBranch guard protects main/dev from accidental edits.\nBypass: ask \"unprotect dev\" or \"bypass branch guard\" (session-scoped)\n\nTry: /craft:do \"your task\"\nOr:  /brainstorm\n\nAfter upgrades, sync Claude Code registry:\n  claude plugin update craft@local-plugins\n\nIf the automatic copy failed (macOS permissions), run manually:\n  mkdir -p ~/.claude/plugins/craft && ( cd $(brew --prefix)/opt/craft/libexec && tar cf - . ) | ( cd ~/.claude/plugins/craft && tar xf - )"
     },
     "himalaya-mcp": {
       "type": "claude-plugin",

--- a/generator/manifest.json
+++ b/generator/manifest.json
@@ -11,6 +11,7 @@
       "source": "github",
       "repo": "Data-Wise/craft",
       "version": "4.5.0",
+      "revision": 1,
       "sha256": "21966e8cb9e518fe013d98de2edb279ec52639fe6cce4212faab12c0f5f3d948",
       "command_count": 48,
       "dependencies": {


### PR DESCRIPTION
## Summary
- craft v4 removed `/craft:git:unprotect` in favor of the `dev/git` skill's "unprotect dev" / "bypass branch guard" phrasing — the Homebrew caveat text still named the removed command.
- Regenerated `Formula/craft.rb` from `generator/manifest.json` (manifest-driven, not hand-edited).

## Test plan
- [x] `brew style data-wise/tap/craft` — 1 file inspected, no offenses
- [x] `brew audit --strict data-wise/tap/craft` — exit 0, no findings
- [x] Verified only `Formula/craft.rb` changed (no drift into other formulas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)