### PR TITLE
flow-cli: update to v7.17.0

### DIFF
--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -5,8 +5,8 @@
 class FlowCli < Formula
   desc "ZSH workflow tools designed for ADHD brains"
   homepage "https://data-wise.github.io/flow-cli/"
-  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v7.16.0.tar.gz"
-  sha256 "033f23f4fc28b07d6d8bd3af103b7893f458fe2ea54e4b002976b89b3ddc309a"
+  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v7.17.0.tar.gz"
+  sha256 "c569d0f1c1be0b11819d828b390111272cd746fac2e271034005bdef34b75f6f"
   license "MIT"
   head "https://github.com/Data-Wise/flow-cli.git", branch: "main"
 


### PR DESCRIPTION
Bumps `Formula/flow-cli.rb` to [v7.17.0](https://github.com/Data-Wise/flow-cli/releases/tag/v7.17.0).

```
url    …/archive/refs/tags/v7.17.0.tar.gz
sha256 c569d0f1c1be0b11819d828b390111272cd746fac2e271034005bdef34b75f6f
```

sha256 verified against the published tarball.

## Why this is a hand-written PR

flow-cli's `homebrew-release` workflow is supposed to do this automatically. It fails on every
release, because it pushes the formula **directly to this repo's `main`** — which is protected
(PR required, 2 status checks):

```
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
##[error]Failed to push after 3 attempts
```

[Data-Wise/flow-cli#499](https://github.com/Data-Wise/flow-cli/pull/499) — "tap formula update via
PR + auto-merge (branch protection on tap main)" — has carried the fix since 2026-07-19 and is
still open. Merging it would make this manual step unnecessary next time.

## On the regen check

`flow-cli` is `"generated": false` in `generator/manifest.json`, so its formula is hand-maintained
and editing `Formula/flow-cli.rb` directly is the correct path — it does not trip the regen drift
check. Verified locally:

```
generator/check-drift.sh                    PASS
generator/check-status-conflict-markers.sh  PASS
generator/check-revision-bump.sh main HEAD  PASS
```

No `revision` bump: this is a version change, not a rebuild of the same version.