### PR TITLE
chore(flow-cli): bump to v7.17.1

### DIFF
--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -5,8 +5,8 @@
 class FlowCli < Formula
   desc "ZSH workflow tools designed for ADHD brains"
   homepage "https://data-wise.github.io/flow-cli/"
-  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v7.17.0.tar.gz"
-  sha256 "c569d0f1c1be0b11819d828b390111272cd746fac2e271034005bdef34b75f6f"
+  url "https://github.com/Data-Wise/flow-cli/archive/refs/tags/v7.17.1.tar.gz"
+  sha256 "37a06cb53fa7d5bf85f2c648f28449cfcd88d493a8d06e48042fd7b641a8ae07"
   license "MIT"
   head "https://github.com/Data-Wise/flow-cli.git", branch: "main"
 


### PR DESCRIPTION
## Summary

Bumps the `flow-cli` formula to v7.17.1 (ships the `tr`-alias-shadowing fix, Data-Wise/flow-cli#509/#510).

Hand-edited, not generator-produced: `generator/manifest.json` marks `flow-cli` `"generated": false`. The automated `homebrew-release.yml` workflow in flow-cli still can't push to this repo's protected `main` (Data-Wise/flow-cli#499, open since 2026-07-19) — this is the manual workaround, same pattern as the v7.17.0 bump.

## Verification

- `generator/check-drift.sh`: pass
- `generator/check-status-conflict-markers.sh`: pass
- `generator/check-revision-bump.sh origin/main HEAD`: pass (7.17.0 → 7.17.1)
- sha256 verified against the published `v7.17.1.tar.gz` release asset

## Test plan

- [ ] CI green on this PR